### PR TITLE
Add method for `groups.listAll` endpoint

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -314,6 +314,13 @@ class RocketChat:
 
     # Groups
 
+    def groups_list_all(self, **kwargs):
+        """
+        List all the private groups on the server.
+        The calling user must have the 'view-room-administration' right
+        """
+        return self.__call_api_get('groups.listAll', kwargs=kwargs)
+
     def groups_list(self, **kwargs):
         """List the private groups the caller is part of."""
         return self.__call_api_get('groups.list', kwargs=kwargs)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -357,6 +357,11 @@ class TestGroups(unittest.TestCase):
     def tearDown(self):
         self.rocket.users_delete(self.testuser.get('user').get('_id'))
 
+    def test_groups_list_all(self):
+        groups_list = self.rocket.groups_list_all().json()
+        self.assertTrue(groups_list.get('success'))
+        self.assertIn('groups', groups_list)
+
     def test_groups_list(self):
         groups_list = self.rocket.groups_list().json()
         self.assertTrue(groups_list.get('success'))


### PR DESCRIPTION
The `groups.listAll` endpoint returns groups belonging to any user. It
can only be accessed by a user with 'view-room-administration'
permissions.

https://rocket.chat/docs/developer-guides/rest-api/groups/listall/

(I'm building an application that needs access to this endpoint.)