### PR TITLE
set_custom_fields method added

### DIFF
--- a/docker-compose-test-server.yml
+++ b/docker-compose-test-server.yml
@@ -2,7 +2,7 @@ version: "2"
 
 services:
   rocketchat:
-    image: rocketchat/rocket.chat:0.64.1
+    image: rocketchat/rocket.chat:0.65.1
     ports:
       - 127.0.0.1:3000:3000
     restart: always

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -491,5 +491,5 @@ class RocketChat:
     def rooms_get(self, **kwargs):
         return self.__call_api_get('rooms.get', kwargs=kwargs)
 
-    def rooms_set_custom_fields(self, rid, custom_fields):
+    def channels_set_custom_fields(self, rid, custom_fields):
         return self.__call_api_post('channels.setCustomFields', roomId=rid, customFields=custom_fields)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -490,6 +490,6 @@ class RocketChat:
 
     def rooms_get(self, **kwargs):
         return self.__call_api_get('rooms.get', kwargs=kwargs)
-    
-    def set_custom_fields(self, rid, custom_fields):
+
+    def rooms_set_custom_fields(self, rid, custom_fields):
         return self.__call_api_post('channels.setCustomFields', roomId=rid, customFields=custom_fields)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -490,3 +490,6 @@ class RocketChat:
 
     def rooms_get(self, **kwargs):
         return self.__call_api_get('rooms.get', kwargs=kwargs)
+    
+    def set_custom_fields(self, rid, custom_fields):
+        return self.__call_api_post('channels.setCustomFields', roomId=rid, customFields=custom_fields)

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -354,6 +354,13 @@ class TestChannels(unittest.TestCase):
         self.assertEqual(channels_set_announcement.get('announcement'), announcement,
                          'Topic does not match')
 
+    def test_channels_set_custom_fields(self):
+        cf = {'key': 'value'}
+        rooms_set_custom_fields = self.rocket.rooms_set_custom_fields('GENERAL', cf).json()
+        self.assertTrue(rooms_set_custom_fields.get('success'))
+        self.assertEqual(cf, rooms_set_custom_fields['channel']['customFields'])
+
+
 
 class TestGroups(unittest.TestCase):
     def setUp(self):
@@ -522,12 +529,6 @@ class TestRooms(unittest.TestCase):
     def test_rooms_get(self):
         rooms_get = self.rocket.rooms_get().json()
         self.assertTrue(rooms_get.get('success'))
-
-    def test_rooms_set_custom_fields(self):
-        cf = {'key': 'value'}
-        rooms_set_custom_fields = self.rocket.rooms_set_custom_fields('GENERAL', cf).json()
-        self.assertTrue(rooms_set_custom_fields.get('success'))
-        self.assertEqual(cf, rooms_set_custom_fields['channel']['customFields'])
 
 
 class TestIMs(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -361,7 +361,6 @@ class TestChannels(unittest.TestCase):
         self.assertEqual(cf, rooms_set_custom_fields['channel']['customFields'])
 
 
-
 class TestGroups(unittest.TestCase):
     def setUp(self):
         self.rocket = RocketChat()

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -527,7 +527,7 @@ class TestRooms(unittest.TestCase):
         cf = {'key': 'value'}
         rooms_set_custom_fields = self.rocket.rooms_set_custom_fields('GENERAL', cf).json()
         self.assertTrue(rooms_set_custom_fields.get('success'))
-        self.assertEqual(cf, rooms_set_custom_fields.get('customFields'))
+        self.assertEqual(cf, rooms_set_custom_fields['channel']['customFields'])
 
 
 class TestIMs(unittest.TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -356,9 +356,9 @@ class TestChannels(unittest.TestCase):
 
     def test_channels_set_custom_fields(self):
         cf = {'key': 'value'}
-        rooms_set_custom_fields = self.rocket.rooms_set_custom_fields('GENERAL', cf).json()
-        self.assertTrue(rooms_set_custom_fields.get('success'))
-        self.assertEqual(cf, rooms_set_custom_fields['channel']['customFields'])
+        channels_set_custom_fields = self.rocket.channels_set_custom_fields('GENERAL', cf).json()
+        self.assertTrue(channels_set_custom_fields.get('success'))
+        self.assertEqual(cf, channels_set_custom_fields['channel']['customFields'])
 
 
 class TestGroups(unittest.TestCase):


### PR DESCRIPTION
Added a call to this method:
https://rocket.chat/docs/developer-guides/rest-api/channels/setcustomfields/