### PR TITLE
Fixing set_avatar argument

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -177,7 +177,7 @@ class RocketChat:
     def users_set_avatar(self, avatar_url, **kwargs):
         """Set a user’s avatar"""
         if avatar_url.startswith('http://') or avatar_url.startswith('https://'):
-            return self.__call_api_post('users.setAvatar', avatarURL=avatar_url, kwargs=kwargs)
+            return self.__call_api_post('users.setAvatar', avatarUrl=avatar_url, kwargs=kwargs)
         else:
             avatar_file = {"image": open(avatar_url, "rb")}
             return self.__call_api_post('users.setAvatar', files=avatar_file, kwargs=kwargs)


### PR DESCRIPTION
## Description 
This is a little fix on set_avatar in accordance with the rocketchat [documentation](https://rocket.chat/docs/developer-guides/rest-api/users/setavatar/),  currently on the code the argument is "avatarURL" and this should be "avatarUrl", the wrong argument generates the error "Unsupported content type: application/json" and doesn't allow to set the image.
## Reviewer 
- [ ] @jadolg 

