### PR TITLE
Add subscriptions.read endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Most of the API methods are already implemented. If you are interested in a spec
 ### Tests
 We are actively testing :) 
 
-Tests run on a Rocket.Chat Docker container so install Docker and docker-compose. To start test server do `docker-compose -f docker-compose-test-setver.yml up` and to take test server down `docker-compose -f docker-compose-test-setver.yml down`
+Tests run on a Rocket.Chat Docker container so install Docker and docker-compose. To start test server do `docker-compose -f docker-compose-test-server.yml up` and to take test server down `docker-compose -f docker-compose-test-server.yml down`
 
 ### Contributing
 You can contribute by doing Pull Requests. (It may take a while to merge your code but if it's good it will be merged). Please, try to implement tests for all your code and use a PEP8 compliant code style.

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -669,6 +669,10 @@ class RocketChat:
         """Mark messages as unread by roomId or from a message"""
         return self.__call_api_post('subscriptions.unread', roomId=room_id, kwargs=kwargs)
 
+    def subscriptions_read(self, rid, **kwargs):
+        """Mark room as read"""
+        return self.__call_api_post('subscriptions.read', rid=rid, kwargs=kwargs)
+
     # Assets
 
     def assets_set_asset(self, asset_name, file, **kwargs):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -975,6 +975,11 @@ class TestSubscriptions(unittest.TestCase):
             room_id='GENERAL').json()
         self.assertTrue(subscriptions_unread.get('success'), 'Call did not succeed')
 
+    def test_subscriptions_read(self):
+        subscriptions_read = self.rocket.subscriptions_read(
+            rid='GENERAL').json()
+        self.assertTrue(subscriptions_read.get('success'), 'Call did not succeed')
+
 
 class TestAssets(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Note: `subscriptions.read` accepts the `rid` argument, whereas `subscriptions.unread` takes `room_id`, which is inconsistent.

I have opted to use the same argument name as RocketChat. Feel free to change it to `room_id` if you want.