### PR TITLE
 add wrappers to the methods to list moderators of channels and groups. 

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -291,6 +291,15 @@ class RocketChat:
         """Removes the role of moderator from a user in the current channel."""
         return self.__call_api_post('channels.removeModerator', roomId=room_id, userId=user_id, kwargs=kwargs)
 
+    def channels_moderators(self, room_id=None, channel=None, **kwargs):
+        """Lists all moderators of a channel."""
+        if room_id:
+            return self.__call_api_get('channels.moderators', roomId=room_id, kwargs=kwargs)
+        elif channel:
+            return self.__call_api_get('channels.moderators', roomName=channel, kwargs=kwargs)
+        else:
+            raise RocketMissingParamException('roomId or channel required')
+
     def channels_add_owner(self, room_id, user_id=None, username=None, **kwargs):
         """Gives the role of owner for a user in the current channel."""
         if user_id:
@@ -436,6 +445,15 @@ class RocketChat:
     def groups_remove_moderator(self, room_id, user_id, **kwargs):
         """Removes the role of moderator from a user in the current groups."""
         return self.__call_api_post('groups.removeModerator', roomId=room_id, userId=user_id, kwargs=kwargs)
+
+    def groups_moderators(self, room_id=None, group=None, **kwargs):
+        """Lists all moderators of a group."""
+        if room_id:
+            return self.__call_api_get('groups.moderators', roomId=room_id, kwargs=kwargs)
+        elif group:
+            return self.__call_api_get('groups.moderators', roomName=group, kwargs=kwargs)
+        else:
+            raise RocketMissingParamException('roomId or group required')
 
     def groups_add_owner(self, room_id, user_id, **kwargs):
         """Gives the role of owner for a user in the current Group."""

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -348,13 +348,13 @@ class TestChannels(unittest.TestCase):
 
     def test_channels_list_moderator(self):
         me = self.rocket.me().json()
-        channels_add_moderator = self.rocket.channels_add_moderator(
-            'GENERAL', me.get('_id')).json()
+        self.rocket.channels_add_moderator(
+            'GENERAL', me.get('_id'))
         channels_list_moderator = self.rocket.channels_moderators(
             room_id='GENERAL').json()
         self.assertTrue(channels_list_moderator.get('success'))
-        channels_remove_moderator = self.rocket.channels_remove_moderator(
-            'GENERAL', me.get('_id')).json()
+        self.rocket.channels_remove_moderator(
+            'GENERAL', me.get('_id'))
 
     def test_channels_add_and_remove_owner(self):
         channels_add_owner = self.rocket.channels_add_owner('GENERAL',

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -347,14 +347,9 @@ class TestChannels(unittest.TestCase):
         self.assertTrue(channels_remove_moderator.get('success'))
 
     def test_channels_list_moderator(self):
-        me = self.rocket.me().json()
-        self.rocket.channels_add_moderator(
-            'GENERAL', me.get('_id'))
         channels_list_moderator = self.rocket.channels_moderators(
             room_id='GENERAL').json()
         self.assertTrue(channels_list_moderator.get('success'))
-        self.rocket.channels_remove_moderator(
-            'GENERAL', me.get('_id'))
 
     def test_channels_add_and_remove_owner(self):
         channels_add_owner = self.rocket.channels_add_owner('GENERAL',
@@ -605,14 +600,9 @@ class TestGroups(unittest.TestCase):
         self.assertTrue(groups_remove_moderator.get('success'))
 
     def test_groups_list_moderator(self):
-        me = self.rocket.me().json()
-        self.rocket.channels_add_moderator(
-            self.test_group_id, me.get('_id'))
         groups_list_moderator = self.rocket.groups_moderators(
             room_id=self.test_group_id).json()
         self.assertTrue(groups_list_moderator.get('success'))
-        self.rocket.channels_remove_moderator(
-            self.test_group_id, me.get('_id'))
 
     def test_groups_add_and_remove_owner(self):
         self.rocket.groups_invite(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -346,6 +346,18 @@ class TestChannels(unittest.TestCase):
             'GENERAL', me.get('_id')).json()
         self.assertTrue(channels_remove_moderator.get('success'))
 
+    def test_channels_list_moderator(self):
+        me = self.rocket.me().json()
+        channels_add_moderator = self.rocket.channels_add_moderator(
+            'GENERAL', me.get('_id')).json()
+        print(channels_add_moderator)
+        channels_list_moderator = self.rocket.channels_moderators(
+            room_id='GENERAL').json()
+        print(channels_list_moderator)
+        self.assertTrue(channels_list_moderator.get('success'))
+        channels_remove_moderator = self.rocket.channels_remove_moderator(
+            'GENERAL', me.get('_id')).json()
+
     def test_channels_add_and_remove_owner(self):
         channels_add_owner = self.rocket.channels_add_owner('GENERAL',
                                                             user_id=self.testuser_id).json()
@@ -593,6 +605,17 @@ class TestGroups(unittest.TestCase):
         groups_remove_moderator = self.rocket.groups_remove_moderator(
             self.test_group_id, me.get('_id')).json()
         self.assertTrue(groups_remove_moderator.get('success'))
+
+    def test_groups_list_moderator(self):
+        me = self.rocket.me().json()
+        self.rocket.channels_add_moderator(
+            self.test_group_id, me.get('_id'))
+        groups_list_moderator = self.rocket.groups_moderators(
+            room_id=self.test_group_id).json()
+        print(groups_list_moderator)
+        self.assertTrue(groups_list_moderator.get('success'))
+        self.rocket.channels_remove_moderator(
+            self.test_group_id, me.get('_id'))
 
     def test_groups_add_and_remove_owner(self):
         self.rocket.groups_invite(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -350,6 +350,12 @@ class TestChannels(unittest.TestCase):
         channels_list_moderator = self.rocket.channels_moderators(
             room_id='GENERAL').json()
         self.assertTrue(channels_list_moderator.get('success'))
+        channel_name = self.rocket.channels_info(room_id='GENERAL').json().get("channel").get("name")
+        channels_list_moderator_by_name = self.rocket.channels_moderators(
+            channel=channel_name).json()
+        self.assertTrue(channels_list_moderator_by_name.get('success'))
+        with self.assertRaises(RocketMissingParamException):
+            self.rocket.channels_moderators()
 
     def test_channels_add_and_remove_owner(self):
         channels_add_owner = self.rocket.channels_add_owner('GENERAL',
@@ -603,6 +609,11 @@ class TestGroups(unittest.TestCase):
         groups_list_moderator = self.rocket.groups_moderators(
             room_id=self.test_group_id).json()
         self.assertTrue(groups_list_moderator.get('success'))
+        groups_list_moderator_by_name = self.rocket.groups_moderators(
+            group=self.test_group_name).json()
+        self.assertTrue(groups_list_moderator_by_name.get('success'))
+        with self.assertRaises(RocketMissingParamException):
+            self.rocket.groups_moderators()
 
     def test_groups_add_and_remove_owner(self):
         self.rocket.groups_invite(

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -350,10 +350,8 @@ class TestChannels(unittest.TestCase):
         me = self.rocket.me().json()
         channels_add_moderator = self.rocket.channels_add_moderator(
             'GENERAL', me.get('_id')).json()
-        print(channels_add_moderator)
         channels_list_moderator = self.rocket.channels_moderators(
             room_id='GENERAL').json()
-        print(channels_list_moderator)
         self.assertTrue(channels_list_moderator.get('success'))
         channels_remove_moderator = self.rocket.channels_remove_moderator(
             'GENERAL', me.get('_id')).json()
@@ -612,7 +610,6 @@ class TestGroups(unittest.TestCase):
             self.test_group_id, me.get('_id'))
         groups_list_moderator = self.rocket.groups_moderators(
             room_id=self.test_group_id).json()
-        print(groups_list_moderator)
         self.assertTrue(groups_list_moderator.get('success'))
         self.rocket.channels_remove_moderator(
             self.test_group_id, me.get('_id'))


### PR DESCRIPTION
Relevant API docs:

* https://rocket.chat/docs/developer-guides/rest-api/groups/moderators/
* https://rocket.chat/docs/developer-guides/rest-api/channels/moderators/