### PR TITLE
Add support for requests.sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,23 @@ pprint(rocket.channels_history('GENERAL', count=5).json())
 
 *note*: every method returns a [requests](https://github.com/kennethreitz/requests) Response object.
 
+#### Connection pooling
+If you are going to make a couple of request, you can user connection pooling provided by `requests`. This will save significant time by avoiding re-negotiation of TLS (SSL) with the chat server on each call.
+
+```
+from requests import sessions
+from pprint import pprint
+from rocketchat_API.rocketchat import RocketChat
+
+with sessions.Session() as session:
+    rocket = RocketChat('user', 'pass', server_url='https://demo.rocket.chat', session=session)
+    pprint(rocket.me().json())
+    pprint(rocket.channels_list().json())
+    pprint(rocket.chat_post_message('good news everyone!', channel='GENERAL', alias='Farnsworth').json())
+    pprint(rocket.channels_history('GENERAL', count=5).json())
+```
+ 
+
 ### Method parameters
 Only required parameters are explicit on the RocketChat class but you can still use all other parameters. For a detailed parameters list check the [Rocket chat API](https://rocket.chat/docs/developer-guides/rest-api/)
 

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -17,13 +17,14 @@ class RocketChat:
 
     def __init__(self, user=None, password=None, auth_token=None, user_id=None,
                  server_url='http://127.0.0.1:3000', ssl_verify=True, proxies=None,
-                 timeout=30):
+                 timeout=30, session=None):
         """Creates a RocketChat object and does login on the specified server"""
         self.headers = {}
         self.server_url = server_url
         self.proxies = proxies
         self.ssl_verify = ssl_verify
         self.timeout = timeout
+        self.req = session or requests
         if user and password:
             self.login(user, password)
         if auth_token and user_id:
@@ -41,7 +42,7 @@ class RocketChat:
 
     def __call_api_get(self, method, **kwargs):
         args = self.__reduce_kwargs(kwargs)
-        return requests.get(self.server_url + self.API_path + method + '?' +
+        return self.req.get(self.server_url + self.API_path + method + '?' +
                             '&'.join([i + '=' + str(args[i])
                                       for i in args.keys()]),
                             headers=self.headers,
@@ -57,7 +58,7 @@ class RocketChat:
         if 'password' in reduced_args and method != 'users.create':
             reduced_args['pass'] = reduced_args['password']
         if use_json:
-            return requests.post(self.server_url + self.API_path + method,
+            return self.req.post(self.server_url + self.API_path + method,
                                  json=reduced_args,
                                  files=files,
                                  headers=self.headers,
@@ -66,7 +67,7 @@ class RocketChat:
                                  timeout=self.timeout
                                  )
         else:
-            return requests.post(self.server_url + self.API_path + method,
+            return self.req.post(self.server_url + self.API_path + method,
                                  data=reduced_args,
                                  files=files,
                                  headers=self.headers,


### PR DESCRIPTION
`requests.get` / `requests.post` are just wrappers that create a separate `requests.sessions.Session` for each API call -- full with establishing TCP connection, TLS negotiation, etc. If one wants to make several requests as a batch the overhead will be significant. Pulling session creation out, effectively getting connection pooling, greatly reduces such overhead.

Like sending out a batch of weekly notifications (120 messages, to 120 channels) takes 64 seconds without using sessions ("before") vs. 21 seconds with a wrapping session ("after").

The change is fully backward compatible and is minimal (I even came up with a nice name for a field to keep original identations 😎).