### PR TITLE
add rooms_admin_rooms

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -42,12 +42,14 @@ class RocketChat:
 
     def __call_api_get(self, method, **kwargs):
         args = self.__reduce_kwargs(kwargs)
-        types = args.pop('types', None)
         url = self.server_url + self.API_path + method
-        params = '&'.join(i + '=' + str(args[i]) for i in args)
-        if types:
-            params += '&' if params else ''
-            params += '&'.join('types[]=%s' % rtype for rtype in types)
+        # convert to key[]=val1&key[]=val2 for args like key=[val1, val2], else key=val
+        params = '&'.join(
+            '&'.join(i + '[]=' + j for j in args[i])
+            if isinstance(args[i], list)
+            else i + '=' + str(args[i])
+            for i in args
+        )
         return self.req.get(
             '%s?%s' % (url, params),
             headers=self.headers,

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -42,14 +42,19 @@ class RocketChat:
 
     def __call_api_get(self, method, **kwargs):
         args = self.__reduce_kwargs(kwargs)
-        return self.req.get(self.server_url + self.API_path + method + '?' +
-                            '&'.join([i + '=' + str(args[i])
-                                      for i in args]),
-                            headers=self.headers,
-                            verify=self.ssl_verify,
-                            proxies=self.proxies,
-                            timeout=self.timeout
-                            )
+        types = args.pop('types', None)
+        url = self.server_url + self.API_path + method
+        params = '&'.join(i + '=' + str(args[i]) for i in args)
+        if types:
+            params += '&' if params else ''
+            params += '&'.join('types[]=%s' % rtype for rtype in types)
+        return self.req.get(
+            '%s?%s' % (url, params),
+            headers=self.headers,
+            verify=self.ssl_verify,
+            proxies=self.proxies,
+            timeout=self.timeout
+        )
 
     def __call_api_post(self, method, files=None, use_json=True, **kwargs):
         reduced_args = self.__reduce_kwargs(kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -690,6 +690,10 @@ class RocketChat:
         else:
             raise RocketMissingParamException('roomId or roomName required')
 
+    def rooms_admin_rooms(self, **kwargs):
+        """ Retrieves all rooms (requires the view-room-administration permission)."""
+        return self.__call_api_get('rooms.adminRooms', kwargs=kwargs)
+
     # Subscriptions
 
     def subscriptions_get(self, **kwargs):

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -54,20 +54,20 @@ def test_rooms_admin_rooms(logged_rocket):
     rooms_simple = logged_rocket.rooms_admin_rooms().json()
     assert rooms_simple.get('success')
 
-    # # Using a room type filter does not seem to work
-    # offset = actual_count = 0
-    # res = {}
-    # while res.get('total') is None or res.get('total') > offset:
-    #     res = logged_rocket.rooms_admin_rooms(
-    #         **{
-    #             'types': ['c',],
-    #             'offset': offset
-    #         }
-    #     ).json()
-    #     assert res.get('success')
-    #     offset += res.get('count')
-    #     actual_count += len(filter(lambda x: 'c' in x['t'], res.get('rooms')))
-    # assert res.get('total') == actual_count
+    # Using a room type filter does not seem to work
+    offset = actual_count = 0
+    res = {}
+    while res.get('total') is None or res.get('total') > offset:
+        res = logged_rocket.rooms_admin_rooms(
+            **{
+                'types': ['c', ],
+                'offset': offset
+            }
+        ).json()
+        assert res.get('success')
+        offset += res.get('count')
+        actual_count += len(list(filter(lambda x: 'c' in x['t'], res.get('rooms'))))
+    assert res.get('total') == actual_count
 
     rooms_with_filter = logged_rocket.rooms_admin_rooms(**{'filter': 'general'}).json()
     assert rooms_with_filter.get('success')

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -69,6 +69,6 @@ def test_rooms_admin_rooms(logged_rocket):
     #     actual_count += len(filter(lambda x: 'c' in x['t'], res.get('rooms')))
     # assert res.get('total') == actual_count
 
-    rooms_with_filter = logged_rocket.rooms_admin_rooms(**{'filter':'general'}).json()
+    rooms_with_filter = logged_rocket.rooms_admin_rooms(**{'filter': 'general'}).json()
     assert rooms_with_filter.get('success')
     assert rooms_with_filter.get('rooms')[0].get('_id') == "GENERAL"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -48,3 +48,27 @@ def test_rooms_info(logged_rocket):
     assert rooms_info_by_id.get('room').get('_id') == "GENERAL"
     with pytest.raises(RocketMissingParamException):
         logged_rocket.rooms_info()
+
+
+def test_rooms_admin_rooms(logged_rocket):
+    rooms_simple = logged_rocket.rooms_admin_rooms().json()
+    assert rooms_simple.get('success')
+
+    # # Using a room type filter does not seem to work
+    # offset = actual_count = 0
+    # res = {}
+    # while res.get('total') is None or res.get('total') > offset:
+    #     res = logged_rocket.rooms_admin_rooms(
+    #         **{
+    #             'types': ['c',],
+    #             'offset': offset
+    #         }
+    #     ).json()
+    #     assert res.get('success')
+    #     offset += res.get('count')
+    #     actual_count += len(filter(lambda x: 'c' in x['t'], res.get('rooms')))
+    # assert res.get('total') == actual_count
+
+    rooms_with_filter = logged_rocket.rooms_admin_rooms(**{'filter':'general'}).json()
+    assert rooms_with_filter.get('success')
+    assert rooms_with_filter.get('rooms')[0].get('_id') == "GENERAL"


### PR DESCRIPTION
Hi there,

This PR adds a wrapper for the [rooms.adminRoom](https://rocket.chat/docs/developer-guides/rest-api/rooms/adminrooms/#rooms-admin-rooms) endpoint.
I could not make the `types` filter work for some reason :/ 
Please let me know if I overlooked something :).