### PR TITLE
Provides an implementation option for #76

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -187,6 +187,7 @@ class RocketChat:
         else:
             raise RocketMissingParamException('userID or username required')
 
+        # If the Accounts_AvatarBlockUnauthorizedAccess is set, we need to provide the Token as cookies
         if response.status_code == 403:
             return self.req.get(response.url, cookies={'rc_uid': self.headers.get('X-User-Id'),
                                                        'rc_token': self.headers.get('X-Auth-Token')})

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -181,11 +181,16 @@ class RocketChat:
     def users_get_avatar(self, user_id=None, username=None, **kwargs):
         """Gets the URL for a user’s avatar."""
         if user_id:
-            return self.__call_api_get('users.getAvatar', userId=user_id, kwargs=kwargs)
+            response = self.__call_api_get('users.getAvatar', userId=user_id, kwargs=kwargs)
         elif username:
-            return self.__call_api_get('users.getAvatar', username=username, kwargs=kwargs)
+            response = self.__call_api_get('users.getAvatar', username=username, kwargs=kwargs)
         else:
             raise RocketMissingParamException('userID or username required')
+
+        if response.status_code == 403:
+            return self.req.get(response.url, cookies={'rc_uid': self.headers.get('X-User-Id'),
+                                                       'rc_token': self.headers.get('X-Auth-Token')})
+        return response
 
     def users_set_avatar(self, avatar_url, **kwargs):
         """Set a user’s avatar"""

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -187,7 +187,7 @@ class RocketChat:
         else:
             raise RocketMissingParamException('userID or username required')
 
-        # If the Accounts_AvatarBlockUnauthorizedAccess is set, we need to provide the Token as cookies
+        # If Accounts_AvatarBlockUnauthorizedAccess is set, we need to provide the Token as cookies
         if response.status_code == 403:
             return self.req.get(response.url, cookies={'rc_uid': self.headers.get('X-User-Id'),
                                                        'rc_token': self.headers.get('X-Auth-Token')})


### PR DESCRIPTION
If you disabled unauthorized access to avatar images,
you need to call the avatars-URL with the uid/token
as cookies, not as headers as with the API.