### PR TITLE
make text optional when chat_post_message

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -231,22 +231,23 @@ class RocketChat:
 
     def chat_post_message(self, text, room_id=None, channel=None, **kwargs):
         """Posts a new chat message."""
-        if text:
-            if room_id:
+        if room_id:
+            if text:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             text=text, kwargs=kwargs)
-            elif channel:
+            else:
+                return self.__call_api_post('chat.postMessage', roomId=room_id,
+                                            kwargs=kwargs)                
+        elif channel:
+            if text:
                 return self.__call_api_post('chat.postMessage',
                                             channel=channel, text=text,
                                             kwargs=kwargs)
-        else:
-            if room_id:
-                return self.__call_api_post('chat.postMessage', roomId=room_id,
-                                            kwargs=kwargs)
-            elif channel:
+            else:
                 return self.__call_api_post('chat.postMessage',
-                                            channel=channel, kwargs=kwargs)
-        raise RocketMissingParamException('roomId or channel required')
+                                            channel=channel, kwargs=kwargs)                
+        else:
+            raise RocketMissingParamException('roomId or channel required')
 
     def chat_get_message(self, msg_id, **kwargs):
         return self.__call_api_get('chat.getMessage', msgId=msg_id, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -236,7 +236,7 @@ class RocketChat:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             text=text, kwargs=kwargs)
             return self.__call_api_post('chat.postMessage', roomId=room_id,
-                                            kwargs=kwargs)                
+                                            kwargs=kwargs)
         elif channel:
             if text:
                 return self.__call_api_post('chat.postMessage',

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -234,19 +234,18 @@ class RocketChat:
         if text:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
-                 text=text, kwargs=kwargs)
+                text=text, kwargs=kwargs)
             if channel:
                 return self.__call_api_post('chat.postMessage',
-                 channel=channel, text=text, kwargs=kwargs)
-            raise RocketMissingParamException('roomId or channel required')
+                channel=channel, text=text, kwargs=kwargs)
         else:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
-                 kwargs=kwargs)
+                kwargs=kwargs)
             if channel:
                 return self.__call_api_post('chat.postMessage',
-                 channel=channel, kwargs=kwargs)
-            raise RocketMissingParamException('roomId or channel required')
+                channel=channel, kwargs=kwargs)
+        raise RocketMissingParamException('roomId or channel required')
 
     def chat_get_message(self, msg_id, **kwargs):
         return self.__call_api_get('chat.getMessage', msgId=msg_id, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -245,7 +245,7 @@ class RocketChat:
                 return self.__call_api_post('chat.postMessage', channel=channel, kwargs=kwargs)
             else:
                 raise RocketMissingParamException('roomId or channel required')
-            
+
 
     def chat_get_message(self, msg_id, **kwargs):
         return self.__call_api_get('chat.getMessage', msgId=msg_id, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -234,17 +234,18 @@ class RocketChat:
         if text:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
-                text=text, kwargs=kwargs)
+                                            text=text, kwargs=kwargs)
             if channel:
                 return self.__call_api_post('chat.postMessage',
-                channel=channel, text=text, kwargs=kwargs)
+                                            channel=channel, text=text,
+                                            kwargs=kwargs)
         else:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
-                kwargs=kwargs)
+                                            kwargs=kwargs)
             if channel:
                 return self.__call_api_post('chat.postMessage',
-                channel=channel, kwargs=kwargs)
+                                            channel=channel, kwargs=kwargs)
         raise RocketMissingParamException('roomId or channel required')
 
     def chat_get_message(self, msg_id, **kwargs):

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -231,12 +231,21 @@ class RocketChat:
 
     def chat_post_message(self, text, room_id=None, channel=None, **kwargs):
         """Posts a new chat message."""
-        if room_id:
-            return self.__call_api_post('chat.postMessage', roomId=room_id, text=text, kwargs=kwargs)
-        elif channel:
-            return self.__call_api_post('chat.postMessage', channel=channel, text=text, kwargs=kwargs)
+        if text:
+            if room_id:
+                return self.__call_api_post('chat.postMessage', roomId=room_id, text=text, kwargs=kwargs)
+            elif channel:
+                return self.__call_api_post('chat.postMessage', channel=channel, text=text, kwargs=kwargs)
+            else:
+                raise RocketMissingParamException('roomId or channel required')
         else:
-            raise RocketMissingParamException('roomId or channel required')
+            if room_id:
+                return self.__call_api_post('chat.postMessage', roomId=room_id, kwargs=kwargs)
+            elif channel:
+                return self.__call_api_post('chat.postMessage', channel=channel, kwargs=kwargs)
+            else:
+                raise RocketMissingParamException('roomId or channel required')
+            
 
     def chat_get_message(self, msg_id, **kwargs):
         return self.__call_api_get('chat.getMessage', msgId=msg_id, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -236,14 +236,14 @@ class RocketChat:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             text=text, kwargs=kwargs)
             return self.__call_api_post('chat.postMessage', roomId=room_id,
-                                            kwargs=kwargs)
+                                        kwargs=kwargs)
         elif channel:
             if text:
                 return self.__call_api_post('chat.postMessage',
                                             channel=channel, text=text,
                                             kwargs=kwargs)
             return self.__call_api_post('chat.postMessage',
-                                            channel=channel, kwargs=kwargs)
+                                        channel=channel, kwargs=kwargs)
         else:
             raise RocketMissingParamException('roomId or channel required')
 

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -233,19 +233,20 @@ class RocketChat:
         """Posts a new chat message."""
         if text:
             if room_id:
-                return self.__call_api_post('chat.postMessage', roomId=room_id, text=text, kwargs=kwargs)
-            elif channel:
-                return self.__call_api_post('chat.postMessage', channel=channel, text=text, kwargs=kwargs)
-            else:
-                raise RocketMissingParamException('roomId or channel required')
+                return self.__call_api_post('chat.postMessage', roomId=room_id,
+                 text=text, kwargs=kwargs)
+            if channel:
+                return self.__call_api_post('chat.postMessage',
+                 channel=channel, text=text, kwargs=kwargs)
+            raise RocketMissingParamException('roomId or channel required')
         else:
             if room_id:
-                return self.__call_api_post('chat.postMessage', roomId=room_id, kwargs=kwargs)
-            elif channel:
-                return self.__call_api_post('chat.postMessage', channel=channel, kwargs=kwargs)
-            else:
-                raise RocketMissingParamException('roomId or channel required')
-
+                return self.__call_api_post('chat.postMessage', roomId=room_id,
+                 kwargs=kwargs)
+            if channel:
+                return self.__call_api_post('chat.postMessage',
+                 channel=channel, kwargs=kwargs)
+            raise RocketMissingParamException('roomId or channel required')
 
     def chat_get_message(self, msg_id, **kwargs):
         return self.__call_api_get('chat.getMessage', msgId=msg_id, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -235,7 +235,7 @@ class RocketChat:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             text=text, kwargs=kwargs)
-            if channel:
+            elif channel:
                 return self.__call_api_post('chat.postMessage',
                                             channel=channel, text=text,
                                             kwargs=kwargs)
@@ -243,7 +243,7 @@ class RocketChat:
             if room_id:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             kwargs=kwargs)
-            if channel:
+            elif channel:
                 return self.__call_api_post('chat.postMessage',
                                             channel=channel, kwargs=kwargs)
         raise RocketMissingParamException('roomId or channel required')

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -235,17 +235,15 @@ class RocketChat:
             if text:
                 return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             text=text, kwargs=kwargs)
-            else:
-                return self.__call_api_post('chat.postMessage', roomId=room_id,
+            return self.__call_api_post('chat.postMessage', roomId=room_id,
                                             kwargs=kwargs)                
         elif channel:
             if text:
                 return self.__call_api_post('chat.postMessage',
                                             channel=channel, text=text,
                                             kwargs=kwargs)
-            else:
-                return self.__call_api_post('chat.postMessage',
-                                            channel=channel, kwargs=kwargs)                
+            return self.__call_api_post('chat.postMessage',
+                                            channel=channel, kwargs=kwargs)
         else:
             raise RocketMissingParamException('roomId or channel required')
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -3,6 +3,14 @@ import pytest
 from rocketchat_API.APIExceptions.RocketExceptions import RocketMissingParamException
 
 
+def test_chat_post_notext_message(logged_rocket):
+    chat_post_message = logged_rocket.chat_post_message(
+        None, channel='GENERAL').json()
+    assert chat_post_message.get('channel') == 'GENERAL'
+    assert chat_post_message.get('message').get('msg') == ''
+    assert chat_post_message.get('success')
+
+
 def test_chat_post_update_delete_message(logged_rocket):
     chat_post_message = logged_rocket.chat_post_message(
         "hello", channel='GENERAL').json()

--- a/tests/test_ims.py
+++ b/tests/test_ims.py
@@ -22,6 +22,13 @@ def test_im_send(logged_rocket, recipient_user):
     assert im_send.get('success')
 
 
+def test_im_send_no_text(logged_rocket, recipient_user):
+    im_create = logged_rocket.im_create(recipient_user).json()
+    room_id = im_create.get('room').get('_id')
+    im_send = logged_rocket.chat_post_message(room_id=room_id, text=None).json()
+    assert im_send.get('success')
+
+
 def test_im_list(logged_rocket, recipient_user):
     logged_rocket.im_create(recipient_user)
     im_list = logged_rocket.im_list().json()


### PR DESCRIPTION
this is to make the text field optional as the Rocket Chat API document states.