### PR TITLE
Json Payload fix for chat_post_message 

### DIFF
--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -79,7 +79,7 @@ class RocketChat:
         if use_json:
             return self.req.post(
                 self.server_url + self.API_path + method,
-                json=reduced_args,
+                json=reduced_args['json'],
                 files=files,
                 headers=self.headers,
                 verify=self.ssl_verify,
@@ -296,7 +296,7 @@ class RocketChat:
 
     # Chat
 
-    def chat_post_message(self, text, room_id=None, channel=None, **kwargs):
+    def chat_post_message(self, text=None, room_id=None, channel=None, **kwargs):
         """Posts a new chat message."""
         if room_id:
             if text:


### PR DESCRIPTION
updated the args for taking only the input json schema for payload while posting a chat message, and also made the text arg optional in chat_post_message call

I was trying to post a message using a json payload for my message. 

What i was looking for was ,
- not using text arg ( in - rocket.chat_post_message())
- and use json payload for building my message

Something like this.
``
payload = {"channel": "#general",
                   "text": "Task completed :heavy_check_mark:\n""`/path/to/file/`"}
rocket.chat_post_message(channel='GENERAL', use_json=True, json=payload)
``

While doing so , i faced a couple of blockage points, 
1. The text args as of now is mandatory to be provided for chat_post_message() , which makes it cumbersome to work with
if we give a empty string for text arg it works fine, like below
`rocket.chat_post_message(text='', channel='GENERAL', use_json=True, json=payload)`
but , doint this way is very cumbersome as we would need to provide it even when we dont require it , as in this case where the message is being build by the json payload.
Suggestion : make the text arg optional

2. When use_json=True in __call_api_post()
the reduced_args json data is not as desired.
Currently the reduced_args variable hold info of additonal keys user, auth_token , which are not required to be passed when using json payload, because of this the json payload is not getting parsed. 
Filtering only the json payload solves this issue.

I have done the changes, and pushed them, please have a look.

