### PR TITLE
Changed the settings so no calls require topt during tests

### DIFF
--- a/docker-compose-test-server.yml
+++ b/docker-compose-test-server.yml
@@ -13,6 +13,7 @@ services:
       - MONGO_URL=mongodb://mongo:27017/rocketchat
       - MONGO_OPLOG_URL=mongodb://mongo:27017/local
       - OVERWRITE_SETTING_API_Enable_Rate_Limiter=false
+      - OVERWRITE_SETTING_Accounts_TwoFactorAuthentication_Enforce_Password_Fallback=false
       - CREATE_TOKENS_FOR_USERS=true
     depends_on:
       - mongo
@@ -22,9 +23,6 @@ services:
   mongo:
     image: mongo:4.0
     restart: unless-stopped
-    volumes:
-     - ./data/db:/data/db
-     - ./data/dump:/dump
     command: mongod --smallfiles --oplogSize 128 --replSet rs0 --storageEngine=mmapv1
 
   # this container's job is just run the command to initialize the replica set.

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,9 +1,3 @@
-import pytest
-
-
-@pytest.mark.skip(
-    reason="the server started requiring TOPT for this method. Skipping till this is fixed."
-)
 def test_settings(logged_rocket):
     settings = logged_rocket.settings().json()
     assert settings.get("success")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -135,9 +135,6 @@ def test_users_create_token(logged_rocket, user):
         logged_rocket.users_create_token()
 
 
-@pytest.mark.skip(
-    reason="the server started requiring TOPT for this method. Skipping till this is fixed."
-)
 def test_users_create_update_delete(logged_rocket, user):
     users_create = logged_rocket.users_create(
         email="email2@domain.com",


### PR DESCRIPTION
Some tests were failing because rocket.chat started requiring TOPT for certain methods making them untestable.
fixes #94 