### PR TITLE
Add livechat methods

### DIFF
--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -47,6 +47,18 @@ class RocketChatBase:
             del kwargs["kwargs"]
         return kwargs
 
+    def call_api_delete(self, method):
+        url = self.server_url + self.API_path + method
+
+        return self.req.delete(
+            url,
+            headers=self.headers,
+            verify=self.ssl_verify,
+            cert=self.cert,
+            proxies=self.proxies,
+            timeout=self.timeout,
+        )
+
     def call_api_get(self, method, **kwargs):
         args = self.__reduce_kwargs(kwargs)
         url = self.server_url + self.API_path + method

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -5,3 +5,7 @@ class RocketChatLivechat(RocketChatBase):
     def livechat_rooms(self, **kwargs):
         """Retrieves a list of livechat rooms."""
         return self.call_api_get("livechat/rooms", kwargs=kwargs)
+
+    def livechat_inquiries_list(self, **kwargs):
+        """Lists all of the open livechat inquiries."""
+        return self.call_api_get("livechat/inquiries.list", kwargs=kwargs)

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -52,3 +52,9 @@ class RocketChatLivechat(RocketChatBase):
         return self.call_api_post(
             "livechat/message", token=token, rid=rid, msg=msg, kwargs=kwargs
         )
+
+    def livechat_messages_history(self, rid, token, **kwargs):
+        """Load Livechat messages history."""
+        return self.call_api_get(
+            f"livechat/messages.history/{rid}", token=token, kwargs=kwargs
+        )

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -1,0 +1,7 @@
+from rocketchat_API.APISections.base import RocketChatBase
+
+
+class RocketChatLivechat(RocketChatBase):
+    def livechat_rooms(self, **kwargs):
+        """Retrieves a list of livechat rooms."""
+        return self.call_api_get("livechat/rooms", kwargs=kwargs)

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -15,3 +15,19 @@ class RocketChatLivechat(RocketChatBase):
         return self.call_api_post(
             "livechat/inquiries.take", inquiryId=inquiry_id, kwargs=kwargs
         )
+
+    def livechat_get_users(self, type, **kwargs):
+        """Get a list of agents or managers."""
+        return self.call_api_get(f"livechat/users/{type}", kwargs=kwargs)
+
+    def livechat_create_user(self, type, **kwargs):
+        """Register a new agent or manager."""
+        return self.call_api_post(f"livechat/users/{type}", kwargs=kwargs)
+
+    def livechat_get_user(self, type, id, **kwargs):
+        """Get info about an agent or manager."""
+        return self.call_api_get(f"livechat/users/{type}/{id}", kwargs=kwargs)
+
+    def livechat_delete_user(self, type, id):
+        """GRemoves an agent or manager."""
+        return self.call_api_delete(f"livechat/users/{type}/{id}")

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -9,3 +9,9 @@ class RocketChatLivechat(RocketChatBase):
     def livechat_inquiries_list(self, **kwargs):
         """Lists all of the open livechat inquiries."""
         return self.call_api_get("livechat/inquiries.list", kwargs=kwargs)
+
+    def livechat_inquiries_take(self, inquiry_id, **kwargs):
+        """Takes an open inquiry."""
+        return self.call_api_post(
+            "livechat/inquiries.take", inquiryId=inquiry_id, kwargs=kwargs
+        )

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -42,3 +42,7 @@ class RocketChatLivechat(RocketChatBase):
     def livechat_get_visitor(self, token):
         """Retrieve a visitor data"""
         return self.call_api_get(f"livechat/visitor/{token}")
+
+    def livechat_room(self, token, **kwargs):
+        """Get the Livechat room data or open a new room."""
+        return self.call_api_get(f"livechat/room/", token=token, kwargs=kwargs)

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -46,3 +46,9 @@ class RocketChatLivechat(RocketChatBase):
     def livechat_room(self, token, **kwargs):
         """Get the Livechat room data or open a new room."""
         return self.call_api_get(f"livechat/room/", token=token, kwargs=kwargs)
+
+    def livechat_message(self, token, rid, msg, **kwargs):
+        """Send a new Livechat message"""
+        return self.call_api_post(
+            "livechat/message", token=token, rid=rid, msg=msg, kwargs=kwargs
+        )

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -40,15 +40,15 @@ class RocketChatLivechat(RocketChatBase):
         return self.call_api_post("livechat/visitor", kwargs=kwargs)
 
     def livechat_get_visitor(self, token):
-        """Retrieve a visitor data"""
+        """Retrieve a visitor data."""
         return self.call_api_get(f"livechat/visitor/{token}")
 
     def livechat_room(self, token, **kwargs):
         """Get the Livechat room data or open a new room."""
-        return self.call_api_get(f"livechat/room/", token=token, kwargs=kwargs)
+        return self.call_api_get("livechat/room/", token=token, kwargs=kwargs)
 
     def livechat_message(self, token, rid, msg, **kwargs):
-        """Send a new Livechat message"""
+        """Send a new Livechat message."""
         return self.call_api_post(
             "livechat/message", token=token, rid=rid, msg=msg, kwargs=kwargs
         )

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -16,18 +16,18 @@ class RocketChatLivechat(RocketChatBase):
             "livechat/inquiries.take", inquiryId=inquiry_id, kwargs=kwargs
         )
 
-    def livechat_get_users(self, type, **kwargs):
+    def livechat_get_users(self, user_type, **kwargs):
         """Get a list of agents or managers."""
-        return self.call_api_get(f"livechat/users/{type}", kwargs=kwargs)
+        return self.call_api_get(f"livechat/users/{user_type}", kwargs=kwargs)
 
-    def livechat_create_user(self, type, **kwargs):
+    def livechat_create_user(self, user_type, **kwargs):
         """Register a new agent or manager."""
-        return self.call_api_post(f"livechat/users/{type}", kwargs=kwargs)
+        return self.call_api_post(f"livechat/users/{user_type}", kwargs=kwargs)
 
-    def livechat_get_user(self, type, id, **kwargs):
+    def livechat_get_user(self, user_type, user_id, **kwargs):
         """Get info about an agent or manager."""
-        return self.call_api_get(f"livechat/users/{type}/{id}", kwargs=kwargs)
+        return self.call_api_get(f"livechat/users/{user_type}/{user_id}", kwargs=kwargs)
 
-    def livechat_delete_user(self, type, id):
+    def livechat_delete_user(self, user_type, user_id):
         """GRemoves an agent or manager."""
-        return self.call_api_delete(f"livechat/users/{type}/{id}")
+        return self.call_api_delete(f"livechat/users/{user_type}/{user_id}")

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -29,5 +29,16 @@ class RocketChatLivechat(RocketChatBase):
         return self.call_api_get(f"livechat/users/{user_type}/{user_id}", kwargs=kwargs)
 
     def livechat_delete_user(self, user_type, user_id):
-        """GRemoves an agent or manager."""
+        """Removes an agent or manager."""
         return self.call_api_delete(f"livechat/users/{user_type}/{user_id}")
+
+    def livechat_register_visitor(self, token, **kwargs):
+        """Register a new Livechat visitor."""
+        if "visitor" not in kwargs:
+            kwargs["visitor"] = {}
+        kwargs["visitor"]["token"] = token
+        return self.call_api_post("livechat/visitor", kwargs=kwargs)
+
+    def livechat_get_visitor(self, token):
+        """Retrieve a visitor data"""
+        return self.call_api_get(f"livechat/visitor/{token}")

--- a/rocketchat_API/APISections/users.py
+++ b/rocketchat_API/APISections/users.py
@@ -150,3 +150,7 @@ class RocketChatUsers(RocketChatBase):
         return self.call_api_post(
             "users.setPreferences", userId=user_id, data=data, kwargs=kwargs
         )
+
+    def users_set_status(self, message, **kwargs):
+        """Sets a user Status when the status message and state is given."""
+        return self.call_api_post("users.setStatus", message=message, kwargs=kwargs)

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -6,6 +6,7 @@ from rocketchat_API.APISections.chat import RocketChatChat
 from rocketchat_API.APISections.groups import RocketChatGroups
 from rocketchat_API.APISections.im import RocketChatIM
 from rocketchat_API.APISections.invites import RocketChatInvites
+from rocketchat_API.APISections.livechat import RocketChatLivechat
 from rocketchat_API.APISections.miscellaneous import RocketChatMiscellaneous
 from rocketchat_API.APISections.permissions import RocketChatPermissions
 from rocketchat_API.APISections.rooms import RocketChatRooms
@@ -31,5 +32,6 @@ class RocketChat(
     RocketChatPermissions,
     RocketChatInvites,
     RocketChatVideConferences,
+    RocketChatLivechat,
 ):
     pass

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -54,7 +54,7 @@ def test_livechat_users(logged_rocket):
     assert len(livechat_users.get("users")) == 0
 
 
-def test_livechat_visitors(logged_rocket):
+def test_livechat_visitor_room_and_message(logged_rocket):
     token = str(uuid.uuid1())
     name = str(uuid.uuid1())
     new_visitor = logged_rocket.livechat_register_visitor(
@@ -80,6 +80,17 @@ def test_livechat_visitors(logged_rocket):
 
     livechat_room = logged_rocket.livechat_room(token=token).json()
     assert livechat_room.get("success")
+    assert "room" in livechat_room
+
+    livechat_message = logged_rocket.livechat_message(
+        token=token,
+        rid=livechat_room.get("room").get("_id"),
+        msg="may the 4th be with you",
+    ).json()
+
+    assert livechat_message.get("success")
+    assert "message" in livechat_message
+    assert livechat_message.get("message").get("msg") == "may the 4th be with you"
 
     livechat_delete_user = logged_rocket.livechat_delete_user(
         user_type="agent", user_id=new_user.get("user").get("_id")

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -17,3 +17,35 @@ def test_livechat_inquiries_take(logged_rocket):
     ).json()
     assert not livechat_inquiries_take.get("success")
     assert "Inquiry already taken" == livechat_inquiries_take.get("reason")
+
+
+def test_livechat_users(logged_rocket):
+    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    assert livechat_users.get("success")
+    assert "users" in livechat_users
+    assert len(livechat_users.get("users")) == 0
+
+    username = logged_rocket.me().json().get("username")
+    new_user = logged_rocket.livechat_create_user(
+        type="agent", username=username
+    ).json()
+    assert new_user.get("success")
+    assert "user" in new_user
+    assert new_user.get("user").get("username") == username
+
+    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    assert len(livechat_users.get("users")) == 1
+
+    livechat_get_user = logged_rocket.livechat_get_user(
+        type="agent", id=new_user.get("user").get("_id")
+    ).json()
+    assert livechat_get_user.get("success")
+    assert new_user.get("user").get("username") == username
+
+    livechat_delete_user = logged_rocket.livechat_delete_user(
+        type="agent", id=new_user.get("user").get("_id")
+    ).json()
+    assert livechat_delete_user.get("success")
+
+    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    assert len(livechat_users.get("users")) == 0

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -20,32 +20,32 @@ def test_livechat_inquiries_take(logged_rocket):
 
 
 def test_livechat_users(logged_rocket):
-    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    livechat_users = logged_rocket.livechat_get_users(user_type="agent").json()
     assert livechat_users.get("success")
     assert "users" in livechat_users
     assert len(livechat_users.get("users")) == 0
 
     username = logged_rocket.me().json().get("username")
     new_user = logged_rocket.livechat_create_user(
-        type="agent", username=username
+        user_type="agent", username=username
     ).json()
     assert new_user.get("success")
     assert "user" in new_user
     assert new_user.get("user").get("username") == username
 
-    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    livechat_users = logged_rocket.livechat_get_users(user_type="agent").json()
     assert len(livechat_users.get("users")) == 1
 
     livechat_get_user = logged_rocket.livechat_get_user(
-        type="agent", id=new_user.get("user").get("_id")
+        user_type="agent", user_id=new_user.get("user").get("_id")
     ).json()
     assert livechat_get_user.get("success")
     assert new_user.get("user").get("username") == username
 
     livechat_delete_user = logged_rocket.livechat_delete_user(
-        type="agent", id=new_user.get("user").get("_id")
+        user_type="agent", user_id=new_user.get("user").get("_id")
     ).json()
     assert livechat_delete_user.get("success")
 
-    livechat_users = logged_rocket.livechat_get_users(type="agent").json()
+    livechat_users = logged_rocket.livechat_get_users(user_type="agent").json()
     assert len(livechat_users.get("users")) == 0

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -54,6 +54,13 @@ def test_livechat_users(logged_rocket):
     assert len(livechat_users.get("users")) == 0
 
 
+def test_livechat_visitor_minimal(logged_rocket):
+    token = str(uuid.uuid1())
+    new_visitor = logged_rocket.livechat_register_visitor(token=token).json()
+    assert new_visitor.get("success")
+    assert "visitor" in new_visitor
+
+
 def test_livechat_visitor_room_and_message(logged_rocket):
     token = str(uuid.uuid1())
     name = str(uuid.uuid1())

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -8,3 +8,12 @@ def test_livechat_inquiries_list(logged_rocket):
     livechat_inquiries_list = logged_rocket.livechat_inquiries_list().json()
     assert livechat_inquiries_list.get("success")
     assert "inquiries" in livechat_inquiries_list
+
+
+def test_livechat_inquiries_take(logged_rocket):
+    # TODO: Find a way of creating an inquiry to be able to properly test this method
+    livechat_inquiries_take = logged_rocket.livechat_inquiries_take(
+        inquiry_id="NotARealThing"
+    ).json()
+    assert not livechat_inquiries_take.get("success")
+    assert "Inquiry already taken" == livechat_inquiries_take.get("reason")

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -1,0 +1,4 @@
+def test_livechat_rooms(logged_rocket):
+    livechat_rooms = logged_rocket.livechat_rooms().json()
+    assert livechat_rooms.get("success")
+    assert "rooms" in livechat_rooms

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -66,3 +66,22 @@ def test_livechat_visitors(logged_rocket):
     get_visitor = logged_rocket.livechat_get_visitor(token=token).json()
     assert get_visitor.get("success")
     assert name == get_visitor.get("visitor").get("username")
+
+    # We need to create a livechat agent and set the user online in order to be able to get a room
+    username = logged_rocket.me().json().get("username")
+    new_user = logged_rocket.livechat_create_user(
+        user_type="agent", username=username
+    ).json()
+    assert new_user.get("success")
+    users_set_status = logged_rocket.users_set_status(
+        message="working on it", status="online"
+    ).json()
+    assert users_set_status.get("success")
+
+    livechat_room = logged_rocket.livechat_room(token=token).json()
+    assert livechat_room.get("success")
+
+    livechat_delete_user = logged_rocket.livechat_delete_user(
+        user_type="agent", user_id=new_user.get("user").get("_id")
+    ).json()
+    assert livechat_delete_user.get("success")

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -99,6 +99,12 @@ def test_livechat_visitor_room_and_message(logged_rocket):
     assert "message" in livechat_message
     assert livechat_message.get("message").get("msg") == "may the 4th be with you"
 
+    livechat_messages_history = logged_rocket.livechat_messages_history(
+        rid=livechat_room.get("room").get("_id"), token=token
+    ).json()
+    assert livechat_messages_history.get("success")
+    assert "messages" in livechat_messages_history
+
     livechat_delete_user = logged_rocket.livechat_delete_user(
         user_type="agent", user_id=new_user.get("user").get("_id")
     ).json()

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -2,3 +2,9 @@ def test_livechat_rooms(logged_rocket):
     livechat_rooms = logged_rocket.livechat_rooms().json()
     assert livechat_rooms.get("success")
     assert "rooms" in livechat_rooms
+
+
+def test_livechat_inquiries_list(logged_rocket):
+    livechat_inquiries_list = logged_rocket.livechat_inquiries_list().json()
+    assert livechat_inquiries_list.get("success")
+    assert "inquiries" in livechat_inquiries_list

--- a/tests/test_livechat.py
+++ b/tests/test_livechat.py
@@ -1,3 +1,6 @@
+import uuid
+
+
 def test_livechat_rooms(logged_rocket):
     livechat_rooms = logged_rocket.livechat_rooms().json()
     assert livechat_rooms.get("success")
@@ -49,3 +52,17 @@ def test_livechat_users(logged_rocket):
 
     livechat_users = logged_rocket.livechat_get_users(user_type="agent").json()
     assert len(livechat_users.get("users")) == 0
+
+
+def test_livechat_visitors(logged_rocket):
+    token = str(uuid.uuid1())
+    name = str(uuid.uuid1())
+    new_visitor = logged_rocket.livechat_register_visitor(
+        token=token, visitor={"username": name}
+    ).json()
+    assert new_visitor.get("success")
+    assert "visitor" in new_visitor
+
+    get_visitor = logged_rocket.livechat_get_visitor(token=token).json()
+    assert get_visitor.get("success")
+    assert name == get_visitor.get("visitor").get("username")

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -210,3 +210,10 @@ def test_users_set_get_preferences(logged_rocket):
 def test_users_list(logged_rocket):
     users_list = logged_rocket.users_list().json()
     assert users_list.get("success")
+
+
+def test_users_set_status(logged_rocket):
+    users_set_status = logged_rocket.users_set_status(
+        message="working on it", status="online"
+    ).json()
+    assert users_set_status.get("success")


### PR DESCRIPTION
Part of the methods present in https://docs.rocket.chat/api/rest-api/methods/livechat have being implemented.
The intent of this PR is not to implement all of them but to make a base for future implementation when there's a need for the methods.