### PR TITLE
Add method to follow a message in a chat

### DIFF
--- a/rocketchat_API/APISections/chat.py
+++ b/rocketchat_API/APISections/chat.py
@@ -85,3 +85,7 @@ class RocketChatChat(RocketChatBase):
             description=description,
             kwargs=kwargs,
         )
+
+    def chat_follow_message(self, mid, **kwargs):
+        """Follows a chat message to the message's channel."""
+        return self.call_api_post("chat.followMessage", mid=mid, kwargs=kwargs)

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -152,3 +152,16 @@ def test_chat_report_message(logged_rocket):
         message_id=message_id, description="this makes me angry"
     ).json()
     assert chat_get_message_report_message.get("success")
+
+
+def test_chat_follow_message(logged_rocket):
+    message_id = (
+        logged_rocket.chat_post_message("hello", channel="GENERAL")
+        .json()
+        .get("message")
+        .get("_id")
+    )
+    chat_get_message_follow_message = logged_rocket.chat_follow_message(
+        mid=message_id
+    ).json()
+    assert chat_get_message_follow_message.get("success")


### PR DESCRIPTION
adds support for https://developer.rocket.chat/reference/api/rest-api/endpoints/team-collaboration-endpoints/chat-endpoints/followmessage