### PR TITLE
Backport to Python 2.7

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '2.7', '3.6', '3.7', '3.8', '3.9' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,9 +27,13 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
-        run: pip install pytest-cov black requests
+        run: pip install pytest-cov requests
+      - name: Install black
+        run: pip install black
+        if: matrix.python-version != '2.7'  # Black does not run on python 2.7
       - name: Lint with black
         run: black --check .
+        if: matrix.python-version != '2.7'  # Black does not run on python 2.7
       - name: Wait for rocket.chat server to be online
         run: until curl --silent http://localhost:3000/api/info/; do sleep 15; echo "waiting for Rocket.Chat server to start"; done
       - name: Run tests

--- a/rocketchat_API/APISections/channels.py
+++ b/rocketchat_API/APISections/channels.py
@@ -14,7 +14,7 @@ class RocketChatChannels(RocketChatBase):
         return self.call_api_get("channels.list.joined", kwargs=kwargs)
 
     def channels_info(self, room_id=None, channel=None, **kwargs):
-        """Gets a channel’s information."""
+        """Gets a channel's information."""
         if room_id:
             return self.call_api_get("channels.info", roomId=room_id, kwargs=kwargs)
         if channel:
@@ -92,11 +92,11 @@ class RocketChatChannels(RocketChatBase):
         return self.call_api_post("channels.unarchive", roomId=room_id, kwargs=kwargs)
 
     def channels_close(self, room_id, **kwargs):
-        """Removes the channel from the user’s list of channels."""
+        """Removes the channel from the user's list of channels."""
         return self.call_api_post("channels.close", roomId=room_id, kwargs=kwargs)
 
     def channels_open(self, room_id, **kwargs):
-        """Adds the channel back to the user’s list of channels."""
+        """Adds the channel back to the user's list of channels."""
         return self.call_api_post("channels.open", roomId=room_id, kwargs=kwargs)
 
     def channels_create(self, name, **kwargs):
@@ -218,7 +218,7 @@ class RocketChatChannels(RocketChatBase):
         raise RocketMissingParamException("room_id or channel required")
 
     def channels_roles(self, room_id=None, room_name=None, **kwargs):
-        """Lists all user’s roles in the channel."""
+        """Lists all user's roles in the channel."""
         if room_id:
             return self.call_api_get("channels.roles", roomId=room_id, kwargs=kwargs)
         if room_name:

--- a/rocketchat_API/APISections/groups.py
+++ b/rocketchat_API/APISections/groups.py
@@ -51,7 +51,7 @@ class RocketChatGroups(RocketChatBase):
         )
 
     def groups_archive(self, room_id, **kwargs):
-        """Archives a private group, only if you’re part of the group."""
+        """Archives a private group, only if you're part of the group."""
         return self.call_api_post("groups.archive", roomId=room_id, kwargs=kwargs)
 
     def groups_unarchive(self, room_id, **kwargs):
@@ -59,11 +59,11 @@ class RocketChatGroups(RocketChatBase):
         return self.call_api_post("groups.unarchive", roomId=room_id, kwargs=kwargs)
 
     def groups_close(self, room_id, **kwargs):
-        """Removes the private group from the user’s list of groups, only if you’re part of the group."""
+        """Removes the private group from the user's list of groups, only if you're part of the group."""
         return self.call_api_post("groups.close", roomId=room_id, kwargs=kwargs)
 
     def groups_create(self, name, **kwargs):
-        """Creates a new private group, optionally including users, only if you’re part of the group."""
+        """Creates a new private group, optionally including users, only if you're part of the group."""
         return self.call_api_post("groups.create", name=name, kwargs=kwargs)
 
     def groups_get_integrations(self, room_id, **kwargs):
@@ -73,7 +73,7 @@ class RocketChatGroups(RocketChatBase):
         )
 
     def groups_info(self, room_id=None, room_name=None, **kwargs):
-        """GRetrieves the information about the private group, only if you’re part of the group."""
+        """GRetrieves the information about the private group, only if you're part of the group."""
         if room_id:
             return self.call_api_get("groups.info", roomId=room_id, kwargs=kwargs)
         if room_name:
@@ -93,11 +93,11 @@ class RocketChatGroups(RocketChatBase):
         )
 
     def groups_leave(self, room_id, **kwargs):
-        """Causes the callee to be removed from the private group, if they’re part of it and are not the last owner."""
+        """Causes the callee to be removed from the private group, if they're part of it and are not the last owner."""
         return self.call_api_post("groups.leave", roomId=room_id, kwargs=kwargs)
 
     def groups_open(self, room_id, **kwargs):
-        """Adds the private group back to the user’s list of private groups."""
+        """Adds the private group back to the user's list of private groups."""
         return self.call_api_post("groups.open", roomId=room_id, kwargs=kwargs)
 
     def groups_rename(self, room_id, name, **kwargs):
@@ -181,7 +181,7 @@ class RocketChatGroups(RocketChatBase):
         raise RocketMissingParamException("room_id or group required")
 
     def groups_roles(self, room_id=None, room_name=None, **kwargs):
-        """Lists all user’s roles in the private group."""
+        """Lists all user's roles in the private group."""
         if room_id:
             return self.call_api_get("groups.roles", roomId=room_id, kwargs=kwargs)
         if room_name:

--- a/rocketchat_API/APISections/im.py
+++ b/rocketchat_API/APISections/im.py
@@ -26,11 +26,11 @@ class RocketChatIM(RocketChatBase):
         )
 
     def im_open(self, room_id, **kwargs):
-        """Adds the direct message back to the user’s list of direct messages."""
+        """Adds the direct message back to the user's list of direct messages."""
         return self.call_api_post("im.open", roomId=room_id, kwargs=kwargs)
 
     def im_close(self, room_id, **kwargs):
-        """Removes the direct message from the user’s list of direct messages."""
+        """Removes the direct message from the user's list of direct messages."""
         return self.call_api_post("im.close", roomId=room_id, kwargs=kwargs)
 
     def im_members(self, room_id, **kwargs):

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -26,7 +26,9 @@ class RocketChatLivechat(RocketChatBase):
 
     def livechat_get_user(self, user_type, user_id, **kwargs):
         """Get info about an agent or manager."""
-        return self.call_api_get("livechat/users/{}/{}".format(user_type, user_id), kwargs=kwargs)
+        return self.call_api_get(
+            "livechat/users/{}/{}".format(user_type, user_id), kwargs=kwargs
+        )
 
     def livechat_delete_user(self, user_type, user_id):
         """Removes an agent or manager."""

--- a/rocketchat_API/APISections/livechat.py
+++ b/rocketchat_API/APISections/livechat.py
@@ -18,19 +18,19 @@ class RocketChatLivechat(RocketChatBase):
 
     def livechat_get_users(self, user_type, **kwargs):
         """Get a list of agents or managers."""
-        return self.call_api_get(f"livechat/users/{user_type}", kwargs=kwargs)
+        return self.call_api_get("livechat/users/{}".format(user_type), kwargs=kwargs)
 
     def livechat_create_user(self, user_type, **kwargs):
         """Register a new agent or manager."""
-        return self.call_api_post(f"livechat/users/{user_type}", kwargs=kwargs)
+        return self.call_api_post("livechat/users/{}".format(user_type), kwargs=kwargs)
 
     def livechat_get_user(self, user_type, user_id, **kwargs):
         """Get info about an agent or manager."""
-        return self.call_api_get(f"livechat/users/{user_type}/{user_id}", kwargs=kwargs)
+        return self.call_api_get("livechat/users/{}/{}".format(user_type, user_id), kwargs=kwargs)
 
     def livechat_delete_user(self, user_type, user_id):
         """Removes an agent or manager."""
-        return self.call_api_delete(f"livechat/users/{user_type}/{user_id}")
+        return self.call_api_delete("livechat/users/{}/{}".format(user_type, user_id))
 
     def livechat_register_visitor(self, token, **kwargs):
         """Register a new Livechat visitor."""
@@ -41,7 +41,7 @@ class RocketChatLivechat(RocketChatBase):
 
     def livechat_get_visitor(self, token):
         """Retrieve a visitor data."""
-        return self.call_api_get(f"livechat/visitor/{token}")
+        return self.call_api_get("livechat/visitor/{}".format(token))
 
     def livechat_room(self, token, **kwargs):
         """Get the Livechat room data or open a new room."""
@@ -56,5 +56,5 @@ class RocketChatLivechat(RocketChatBase):
     def livechat_messages_history(self, rid, token, **kwargs):
         """Load Livechat messages history."""
         return self.call_api_get(
-            f"livechat/messages.history/{rid}", token=token, kwargs=kwargs
+            "livechat/messages.history/{}".format(rid), token=token, kwargs=kwargs
         )

--- a/rocketchat_API/APISections/users.py
+++ b/rocketchat_API/APISections/users.py
@@ -11,7 +11,7 @@ class RocketChatUsers(RocketChatBase):
         return self.call_api_get("me", kwargs=kwargs)
 
     def users_info(self, user_id=None, username=None, **kwargs):
-        """Gets a user’s information, limited to the caller’s permissions."""
+        """Gets a user's information, limited to the caller's permissions."""
         if user_id:
             return self.call_api_get("users.info", userId=user_id, kwargs=kwargs)
         if username:
@@ -59,7 +59,7 @@ class RocketChatUsers(RocketChatBase):
         )
 
     def users_get_avatar(self, user_id=None, username=None, **kwargs):
-        """Gets the URL for a user’s avatar."""
+        """Gets the URL for a user's avatar."""
         if user_id:
             response = self.call_api_get(
                 "users.getAvatar", userId=user_id, kwargs=kwargs
@@ -84,7 +84,7 @@ class RocketChatUsers(RocketChatBase):
         return response
 
     def users_set_avatar(self, avatar_url, **kwargs):
-        """Set a user’s avatar"""
+        """Set a user's avatar"""
         if avatar_url.startswith("http://") or avatar_url.startswith("https://"):
             return self.call_api_post(
                 "users.setAvatar", avatarUrl=avatar_url, kwargs=kwargs
@@ -101,7 +101,7 @@ class RocketChatUsers(RocketChatBase):
         return self.call_api_post("users.setAvatar", files=avatar_file, kwargs=kwargs)
 
     def users_reset_avatar(self, user_id=None, username=None, **kwargs):
-        """Reset a user’s avatar"""
+        """Reset a user's avatar"""
         if user_id:
             return self.call_api_post(
                 "users.resetAvatar", userId=user_id, kwargs=kwargs
@@ -146,7 +146,7 @@ class RocketChatUsers(RocketChatBase):
         return self.call_api_get("users.getPreferences", kwargs=kwargs)
 
     def users_set_preferences(self, user_id, data, **kwargs):
-        """Set user’s preferences."""
+        """Set user's preferences."""
         return self.call_api_post(
             "users.setPreferences", userId=user_id, data=data, kwargs=kwargs
         )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -140,7 +140,7 @@ def test_users_create_token(logged_rocket, user):
 def test_users_create_update_delete(logged_rocket, user):
     name = str(uuid.uuid1())
     users_create = logged_rocket.users_create(
-        email=f"{name}@domain.com",
+        email="{}@domain.com".format(name),
         name=name,
         password=user.password,
         username=name,


### PR DESCRIPTION
Reading https://github.com/jadolg/rocketchat_API/issues/3, it looks like at least at one point there was a desire to support python 2.7. 
While it's meant to be dead and buried right now, I've had to add support for it today for usage along with some other libraries and compiled programs that haven't been updated yet.

Seeing as the changes required to make it work in python 2.7 were very minimal, maybe you would like to merge it.
All that was required was replacing the non-ascii apostrophe used in some docstrings with an ascii apostrophe, and replacing a few f-strings with str.format().