### PR TITLE
Add integrations endpoints

### DIFF
--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -114,6 +114,40 @@ class RocketChatBase:
             timeout=self.timeout,
         )
 
+    def call_api_put(self, method, files=None, use_json=None, **kwargs):
+        reduced_args = self.__reduce_kwargs(kwargs)
+        # Since pass is a reserved word in Python it has to be injected on the request dict
+        # Some methods use pass (users.register) and others password (users.create)
+        if "password" in reduced_args and method != "users.create":
+            reduced_args["pass"] = reduced_args["password"]
+            del reduced_args["password"]
+        if use_json is None:
+            # see https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests
+            # > The json parameter is ignored if either data or files is passed.
+            # If files are sent, json should not be used
+            use_json = files is None
+        if use_json:
+            return self.req.put(
+                self.server_url + self.API_path + method,
+                json=reduced_args,
+                files=files,
+                headers=self.headers,
+                verify=self.ssl_verify,
+                cert=self.cert,
+                proxies=self.proxies,
+                timeout=self.timeout,
+            )
+        return self.req.put(
+            self.server_url + self.API_path + method,
+            data=reduced_args,
+            files=files,
+            headers=self.headers,
+            verify=self.ssl_verify,
+            cert=self.cert,
+            proxies=self.proxies,
+            timeout=self.timeout,
+        )
+
     # Authentication
 
     def login(self, user, password):

--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -116,11 +116,6 @@ class RocketChatBase:
 
     def call_api_put(self, method, files=None, use_json=None, **kwargs):
         reduced_args = self.__reduce_kwargs(kwargs)
-        # Since pass is a reserved word in Python it has to be injected on the request dict
-        # Some methods use pass (users.register) and others password (users.create)
-        if "password" in reduced_args and method != "users.create":
-            reduced_args["pass"] = reduced_args["password"]
-            del reduced_args["password"]
         if use_json is None:
             # see https://requests.readthedocs.io/en/master/user/quickstart/#more-complicated-post-requests
             # > The json parameter is ignored if either data or files is passed.

--- a/rocketchat_API/APISections/integrations.py
+++ b/rocketchat_API/APISections/integrations.py
@@ -1,0 +1,91 @@
+from rocketchat_API.APISections.base import RocketChatBase
+
+
+class RocketChatIntegrations(RocketChatBase):
+    # pylint: disable=too-many-arguments
+    def integrations_create(
+        self,
+        integrations_type,
+        name,
+        enabled,
+        username,
+        channel,
+        script_enabled,
+        event=None,
+        urls=None,
+        **kwargs
+    ):
+        """Creates an integration."""
+        if integrations_type == "webhook-outgoing":
+            return self.call_api_post(
+                "integrations.create",
+                type=integrations_type,
+                name=name,
+                enabled=enabled,
+                event=event,
+                urls=urls,
+                username=username,
+                channel=channel,
+                scriptEnabled=script_enabled,
+                kwargs=kwargs,
+            )
+
+        return self.call_api_post(
+            "integrations.create",
+            type=integrations_type,
+            name=name,
+            enabled=enabled,
+            username=username,
+            channel=channel,
+            scriptEnabled=script_enabled,
+            kwargs=kwargs,
+        )
+
+    def integrations_get(self, integration_id, **kwargs):
+        """Retrieves an integration by id."""
+        return self.call_api_get(
+            "integrations.get", integrationId=integration_id, kwargs=kwargs
+        )
+
+    def integrations_history(self, integration_id, **kwargs):
+        """Lists all history of the specified integration."""
+        return self.call_api_get(
+            "integrations.history", id=integration_id, kwargs=kwargs
+        )
+
+    def integrations_list(self, **kwargs):
+        """Lists all of the integrations on the server."""
+        return self.call_api_get("integrations.list", kwargs=kwargs)
+
+    def integrations_remove(self, integrations_type, integration_id, **kwargs):
+        """Removes an integration from the server."""
+        return self.call_api_post(
+            "integrations.remove",
+            type=integrations_type,
+            integrationId=integration_id,
+            kwargs=kwargs,
+        )
+
+    def integrations_update(
+        self,
+        integrations_type,
+        name,
+        enabled,
+        username,
+        channel,
+        script_enabled,
+        integration_id,
+        **kwargs
+    ):
+        """Updates an existing integration."""
+        return self.call_api_put(
+            "integrations.update",
+            type=integrations_type,
+            name=name,
+            enabled=enabled,
+            username=username,
+            channel=channel,
+            scriptEnabled=script_enabled,
+            integrationId=integration_id,
+            kwargs=kwargs,
+        )

--- a/rocketchat_API/rocketchat.py
+++ b/rocketchat_API/rocketchat.py
@@ -5,6 +5,7 @@ from rocketchat_API.APISections.channels import RocketChatChannels
 from rocketchat_API.APISections.chat import RocketChatChat
 from rocketchat_API.APISections.groups import RocketChatGroups
 from rocketchat_API.APISections.im import RocketChatIM
+from rocketchat_API.APISections.integrations import RocketChatIntegrations
 from rocketchat_API.APISections.invites import RocketChatInvites
 from rocketchat_API.APISections.livechat import RocketChatLivechat
 from rocketchat_API.APISections.miscellaneous import RocketChatMiscellaneous
@@ -25,6 +26,7 @@ class RocketChat(
     RocketChatChannels,
     RocketChatGroups,
     RocketChatIM,
+    RocketChatIntegrations,
     RocketChatStatistics,
     RocketChatMiscellaneous,
     RocketChatSettings,

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -1,0 +1,74 @@
+from uuid import uuid1
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def integrations_create_webhook_incoming(logged_rocket):
+    return logged_rocket.integrations_create(
+        integrations_type="webhook-incoming",
+        name=str(uuid1()),
+        enabled=True,
+        username=logged_rocket.me().json().get("username"),
+        channel="#general",
+        script_enabled=False,
+    ).json()
+
+
+def test_integrations_create(integrations_create_webhook_incoming, logged_rocket):
+    integration_webhook_incoming = integrations_create_webhook_incoming
+    assert integration_webhook_incoming.get("success")
+
+    integration_webhook_outgoing = logged_rocket.integrations_create(
+        integrations_type="webhook-incoming",
+        name=str(uuid1()),
+        enabled=True,
+        event="sendMessage",
+        username=logged_rocket.me().json().get("username"),
+        urls=["http://example.com/fake"],
+        channel="#general",
+        script_enabled=False,
+    ).json()
+    assert integration_webhook_outgoing.get("success")
+
+
+def test_integrations_get(integrations_create_webhook_incoming, logged_rocket):
+    integration_id = integrations_create_webhook_incoming.get("integration").get("_id")
+    assert logged_rocket.integrations_get(integration_id).json().get("success")
+
+
+def test_integrations_history(integrations_create_webhook_incoming, logged_rocket):
+    integration_id = integrations_create_webhook_incoming.get("integration").get("_id")
+    assert logged_rocket.integrations_history(integration_id).json().get("success")
+
+
+def test_integrations_list(logged_rocket):
+    assert logged_rocket.integrations_list().json().get("success")
+
+
+def test_integrations_remove(integrations_create_webhook_incoming, logged_rocket):
+    integration = integrations_create_webhook_incoming.get("integration")
+    assert (
+        logged_rocket.integrations_remove(
+            integration.get("type"), integration.get("_id")
+        )
+        .json()
+        .get("success")
+    )
+
+
+def test_integrations_update(integrations_create_webhook_incoming, logged_rocket):
+    integration_id = integrations_create_webhook_incoming.get("integration").get("_id")
+    assert (
+        logged_rocket.integrations_update(
+            integrations_type="webhook-incoming",
+            name=str(uuid1()),
+            enabled=False,
+            username=logged_rocket.me().json().get("username"),
+            channel="#general",
+            script_enabled=False,
+            integration_id=integration_id,
+        )
+        .json()
+        .get("success")
+    )

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -20,7 +20,7 @@ def test_integrations_create(integrations_create_webhook_incoming, logged_rocket
     assert integration_webhook_incoming.get("success")
 
     integration_webhook_outgoing = logged_rocket.integrations_create(
-        integrations_type="webhook-incoming",
+        integrations_type="webhook-outgoing",
         name=str(uuid1()),
         enabled=True,
         event="sendMessage",

--- a/tests/test_integrations.py
+++ b/tests/test_integrations.py
@@ -25,7 +25,7 @@ def test_integrations_create(integrations_create_webhook_incoming, logged_rocket
         enabled=True,
         event="sendMessage",
         username=logged_rocket.me().json().get("username"),
-        urls=["http://example.com/fake"],
+        urls=["https://example.com/fake"],
         channel="#general",
         script_enabled=False,
     ).json()


### PR DESCRIPTION
This PR adds integrations (webhooks) endpoints.
I took a shortcut and copy/pasted `call_api_post()` to create `call_api_put()` since it is needed for the `integrations.update` endpoint. It could probably be improved later, but the current version should be sufficient for now.