### PR TITLE
Fix the asset.setAsset method

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 requests==2.28.1
+packaging~=21.3

--- a/rocketchat_API/APISections/assets.py
+++ b/rocketchat_API/APISections/assets.py
@@ -1,17 +1,26 @@
 import mimetypes
 
+from packaging import version
+
 from rocketchat_API.APISections.base import RocketChatBase
 
 
 class RocketChatAssets(RocketChatBase):
     def assets_set_asset(self, asset_name, file, **kwargs):
         """Set an asset image by name."""
+        server_info = self.info().json()
         content_type = mimetypes.MimeTypes().guess_type(file)
+
+        file_name = asset_name
+        if version.parse(server_info.get("info").get("version")) >= version.parse("5.1"):
+            file_name = "asset"
+
         files = {
-            asset_name: (file, open(file, "rb"), content_type[0], {"Expires": "0"}),
+            file_name: (file, open(file, "rb"), content_type[0], {"Expires": "0"}),
         }
+
         return self.call_api_post(
-            "assets.setAsset", kwargs=kwargs, use_json=False, files=files
+            "assets.setAsset", kwargs=kwargs, assetName=asset_name, use_json=False, files=files
         )
 
     def assets_unset_asset(self, asset_name):

--- a/rocketchat_API/APISections/assets.py
+++ b/rocketchat_API/APISections/assets.py
@@ -12,7 +12,9 @@ class RocketChatAssets(RocketChatBase):
         content_type = mimetypes.MimeTypes().guess_type(file)
 
         file_name = asset_name
-        if version.parse(server_info.get("info").get("version")) >= version.parse("5.1"):
+        if version.parse(server_info.get("info").get("version")) >= version.parse(
+            "5.1"
+        ):
             file_name = "asset"
 
         files = {
@@ -20,7 +22,11 @@ class RocketChatAssets(RocketChatBase):
         }
 
         return self.call_api_post(
-            "assets.setAsset", kwargs=kwargs, assetName=asset_name, use_json=False, files=files
+            "assets.setAsset",
+            kwargs=kwargs,
+            assetName=asset_name,
+            use_json=False,
+            files=files,
         )
 
     def assets_unset_asset(self, asset_name):

--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -180,3 +180,7 @@ class RocketChatBase:
     def logout(self, **kwargs):
         """Invalidate your REST rocketchat_API authentication token."""
         return self.call_api_post("logout", kwargs=kwargs)
+
+    def info(self, **kwargs):
+        """Information about the Rocket.Chat server."""
+        return self.call_api_get("info", api_path="/api/", kwargs=kwargs)

--- a/rocketchat_API/APISections/miscellaneous.py
+++ b/rocketchat_API/APISections/miscellaneous.py
@@ -3,10 +3,6 @@ from rocketchat_API.APISections.base import RocketChatBase
 
 class RocketChatMiscellaneous(RocketChatBase):
     # Miscellaneous information
-    def info(self, **kwargs):
-        """Information about the Rocket.Chat server."""
-        return self.call_api_get("info", api_path="/api/", kwargs=kwargs)
-
     def directory(self, query, **kwargs):
         """Search by users or channels on all server."""
         if isinstance(query, dict):

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,5 @@ setup(
     description="Python API wrapper for Rocket.Chat",
     long_description=open("README.md", "r").read(),
     long_description_content_type="text/markdown",
-    install_requires=("requests",),
+    install_requires=("requests", "packaging"),
 )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -12,17 +12,17 @@ def test_chat_post_notext_message(logged_rocket):
 
 def test_chat_post_update_delete_message(logged_rocket):
     chat_post_message = logged_rocket.chat_post_message(
-        "hello", channel="GENERAL",
+        "hello",
+        channel="GENERAL",
         attachments=[
-            {
-                "color": "#ff0000",
-                "text": "there"
-            },
-        ]
+            {"color": "#ff0000", "text": "there"},
+        ],
     ).json()
     assert chat_post_message.get("channel") == "GENERAL"
     assert chat_post_message.get("message").get("msg") == "hello"
-    assert chat_post_message.get("message").get("attachments")[0].get("color") == "#ff0000"
+    assert (
+        chat_post_message.get("message").get("attachments")[0].get("color") == "#ff0000"
+    )
     assert chat_post_message.get("message").get("attachments")[0].get("text") == "there"
     assert chat_post_message.get("success")
 

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -12,10 +12,18 @@ def test_chat_post_notext_message(logged_rocket):
 
 def test_chat_post_update_delete_message(logged_rocket):
     chat_post_message = logged_rocket.chat_post_message(
-        "hello", channel="GENERAL"
+        "hello", channel="GENERAL",
+        attachments=[
+            {
+                "color": "#ff0000",
+                "text": "there"
+            },
+        ]
     ).json()
     assert chat_post_message.get("channel") == "GENERAL"
     assert chat_post_message.get("message").get("msg") == "hello"
+    assert chat_post_message.get("message").get("attachments")[0].get("color") == "#ff0000"
+    assert chat_post_message.get("message").get("attachments")[0].get("text") == "there"
     assert chat_post_message.get("success")
 
     with pytest.raises(RocketMissingParamException):


### PR DESCRIPTION
starting in version 5.1, the behavior of the endpoint changed. In order to handle the difference, the wrapper needs to act differently for different versions