### PR TITLE
Use ubuntu 20.04 instead of ubuntu-latest to run tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         python-version: [ '2.7', '3.8', '3.9', '3.10' ]


### PR DESCRIPTION
looks like the setup action does not work correctly with the latest ubuntu runner. See https://github.com/actions/setup-python/issues/543 for more information.
