### PR TITLE
Temporarily skip testing endpoints that are now part of the enterprise version.

### DIFF
--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -135,6 +135,8 @@ def test_chat_search(logged_rocket):
     assert chat_search.get("success")
 
 
+# ToDo: Remove skip once we have a key to test with.
+@pytest.mark.skip(reason="This endpoint is now part of the enterprise version.")
 def test_chat_get_message_read_receipts(logged_rocket):
     message_id = (
         logged_rocket.chat_post_message("hello", channel="GENERAL")

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -1,5 +1,7 @@
 import uuid
 
+import pytest
+
 
 def test_roles_list(logged_rocket):
     roles_list = logged_rocket.roles_list().json()
@@ -7,6 +9,8 @@ def test_roles_list(logged_rocket):
     assert len(roles_list.get("roles")) > 0
 
 
+# ToDo: Remove skip once we have a key to test with.
+@pytest.mark.skip(reason="This endpoint is now part of the enterprise version.")
 def test_roles_create(logged_rocket):
     name = str(uuid.uuid1())
     roles_create = logged_rocket.roles_create(


### PR DESCRIPTION
We are already talking about the possibility of getting a key for testing. In the meantime, these 2 tests need to be skipped since the endpoints are no longer publically available.