### PR TITLE
add chat.getThreadMessages

### DIFF
--- a/rocketchat_API/APISections/chat.py
+++ b/rocketchat_API/APISections/chat.py
@@ -89,3 +89,11 @@ class RocketChatChat(RocketChatBase):
     def chat_follow_message(self, mid, **kwargs):
         """Follows a chat message to the message's channel."""
         return self.call_api_post("chat.followMessage", mid=mid, kwargs=kwargs)
+
+    def chat_get_thread_messages(self, thread_msg_id, **kwargs):
+        """Get thread messages."""
+        return self.call_api_get(
+            "chat.getThreadMessages",
+            tmid=thread_msg_id,
+            kwargs=kwargs,
+        )

--- a/tests/test_chat.py
+++ b/tests/test_chat.py
@@ -173,3 +173,40 @@ def test_chat_follow_message(logged_rocket):
         mid=message_id
     ).json()
     assert chat_get_message_follow_message.get("success")
+
+
+def test_chat_get_thread_messages(logged_rocket):
+    chat_post_message1 = logged_rocket.chat_post_message(
+        "text1",
+        channel="GENERAL",
+    ).json()
+    msg1_id = chat_post_message1.get("message").get("_id")
+
+    chat_post_message2 = logged_rocket.chat_post_message(
+        "text2",
+        channel="GENERAL",
+        tmid=msg1_id,
+    ).json()
+
+    chat_post_message3 = logged_rocket.chat_post_message(
+        "text3",
+        channel="GENERAL",
+        tmid=msg1_id,
+        tshow="False",
+    ).json()
+
+    chat_get_thread_messages = logged_rocket.chat_get_thread_messages(
+        thread_msg_id=msg1_id,
+    ).json()
+
+    # check that correct number of messages is returned
+    assert chat_get_thread_messages.get("count") == 2
+
+    # check that text of messages are correct and messages are returned in order
+    assert chat_get_thread_messages.get("messages")[0].get(
+        "msg"
+    ) == chat_post_message2.get("message").get("msg")
+    assert chat_get_thread_messages.get("messages")[1].get(
+        "msg"
+    ) == chat_post_message3.get("message").get("msg")
+    assert chat_get_thread_messages.get("success")


### PR DESCRIPTION
Adds the [Get Thread Messages call](https://developer.rocket.chat/reference/api/rest-api/endpoints/messaging/chat-endpoints/getthreadmessages). I followed what looked to be the pattern of expanding parameters into underscores between lowercase words (e.g. `tmid=thread_msg_id`)

Note: The docs say the `tlm` query parameter is required, but it is not actually supported. I have a pull request in to rocketchat developer docs to correct, https://github.com/RocketChat/developer-docs/pull/196

I made a pretty simple test, at least to start: it posts one message and two replies, then gets thread messages. Checks count of messages and their text. And the `success` field. I tested this with the docker setup in this repo - it was very easy, thank you!

Is that sufficient, or do you usually like to check more of the message details or have other handling in there?