### PR TITLE
Remove Python 3.8 from the test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.9', '3.10', '3.11', '3.12' ]
         rocket-chat-version: [ '6.7.9', '6.8.7','6.9.7','6.10.6','6.11.3','6.12.1', '6.13.0', 'latest' ]
     steps:
       - name: Checkout


### PR DESCRIPTION
Reached EOL 2024-10-07