### PR TITLE
Remove "latest" from testing matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ '3.9', '3.10', '3.11', '3.12', '3.13', ]
-        rocket-chat-version: [ '6.11.3','6.12.3', '6.13.1', '7.0.5', '7.1.1', '7.2.1', '7.3.0', 'latest' ]
+        rocket-chat-version: [ '6.11.3','6.12.3', '6.13.1', '7.0.5', '7.1.1', '7.2.1', '7.3.0' ]
     steps:
       - name: Checkout
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This removes double testing and avoids introducing failing tests unintentionally.
We only explicitly support what's on the testing matrix.

downside: Now learning if the new version fails doesn't happen automatically