### PR TITLE
replace kwargs double backslash for multiline messages

### DIFF
--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -83,6 +83,12 @@ class RocketChatBase:
         )
 
     def call_api_post(self, method, files=None, use_json=None, **kwargs):
+        if "text" in kwargs:
+            kwargs["text"] = kwargs["text"].replace('\\n', '\n')
+            kwargs["text"] = kwargs["text"].replace('\\r', '\r')
+            kwargs["text"] = kwargs["text"].replace('\\t', '\t')
+            kwargs["text"] = kwargs["text"].replace('\\b', '\b')
+            kwargs["text"] = kwargs["text"].replace('\\f', '\f')
         reduced_args = self.__reduce_kwargs(kwargs)
         # Since pass is a reserved word in Python it has to be injected on the request dict
         # Some methods use pass (users.register) and others password (users.create)


### PR DESCRIPTION
rocketchat_API/APISections/base.py line 86

if you want to use the api to send multiline messages, you have to adapt the kwargs arguments.

the kwargs arguments are json serialized and have problems with escape sequences.

I fixed this here.