### PR TITLE
Remove query parameter from `channels_online`

### DIFF
--- a/rocketchat_API/APISections/channels.py
+++ b/rocketchat_API/APISections/channels.py
@@ -1,6 +1,3 @@
-import json
-import logging
-
 from rocketchat_API.APIExceptions.RocketExceptions import RocketMissingParamException
 from rocketchat_API.APISections.base import RocketChatBase
 


### PR DESCRIPTION
Deprecated in V7 and V6 is no longer supported