### PR TITLE
Fix pagination decorator to accept positional and keyword arguments

### DIFF
--- a/rocketchat_API/APISections/base.py
+++ b/rocketchat_API/APISections/base.py
@@ -34,7 +34,7 @@ def paginated(data_key):
     """
 
     def decorator(func):
-        def _generator(self, first_data, offset, count, **kwargs):
+        def _generator(self, first_data, offset, count, args, kwargs):
             """Inner generator that yields items from paginated API responses."""
             data = first_data
             while True:
@@ -51,17 +51,17 @@ def paginated(data_key):
 
                 offset += count
                 # Call the original function with pagination parameters
-                data = func(self, offset=offset, count=count, **kwargs)
+                data = func(self, *args, offset=offset, count=count, **kwargs)
 
         @wraps(func)
-        def wrapper(self, **kwargs):
+        def wrapper(self, *args, **kwargs):
             offset = kwargs.pop("offset", 0)
             count = kwargs.pop("count", 50)
 
             # Call the original function eagerly to propagate any exceptions
-            first_data = func(self, offset=offset, count=count, **kwargs)
+            first_data = func(self, *args, offset=offset, count=count, **kwargs)
 
-            return _generator(self, first_data, offset, count, **kwargs)
+            return _generator(self, first_data, offset, count, args, kwargs)
 
         return wrapper
 

--- a/tests/test_groups.py
+++ b/tests/test_groups.py
@@ -80,9 +80,18 @@ def test_groups_history(logged_rocket, test_group_id):
     logged_rocket.chat_post_message(
         room_id=test_group_id, text="Testing groups_history"
     )
-    iterated_messages = list(logged_rocket.groups_history(room_id=test_group_id))
-    for message in iterated_messages:
+
+    # Test with positional argument
+    for message in logged_rocket.groups_history(test_group_id):
         assert "_id" in message
+        assert "msg" in message
+        assert message.get("msg") == "Testing groups_history"
+
+    # Test with keyword argument
+    for message in logged_rocket.groups_history(room_id=test_group_id):
+        assert "_id" in message
+        assert "msg" in message
+        assert message.get("msg") == "Testing groups_history"
 
 
 def test_groups_add_and_remove_moderator(logged_rocket, test_group_id):


### PR DESCRIPTION
The paginated decorator's wrapper function only accepts **kwargs, but the groups_history method expects a positional room_id argument. The decorator needs to be updated to handle both positional and keyword arguments.