### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,8 @@
 name: Lint
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/rocketchat_API/security/code-scanning/3](https://github.com/jadolg/rocketchat_API/security/code-scanning/3)

In general, the fix is to explicitly define the `permissions` for the `GITHUB_TOKEN` in the workflow, restricting it to the minimal required scope. For this particular lint job, the only capability needed is reading the repository contents so that `actions/checkout` can fetch the code. No steps require writing to the repository or interacting with issues, pull requests, or other resources.

The best fix without changing existing functionality is to add a `permissions` block at the workflow (top) level, immediately under `name: Lint`. This block will apply to all jobs (currently only `lint`) that do not override it. We should set `contents: read`, which is sufficient for `actions/checkout` and does not grant any write privileges. No additional imports, methods, or definitions are needed because this is just a YAML configuration change.

Concretely:
- Edit `.github/workflows/lint.yml`.
- Insert:

```yaml
permissions:
  contents: read
```

- Place it after line 1 (`name: Lint`) and before the `on:` block, keeping indentation consistent (top-level keys, no indentation).
- Leave the rest of the workflow unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
