### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_latest.yml
+++ b/.github/workflows/test_latest.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 20 * * 5'
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/rocketchat_API/security/code-scanning/5](https://github.com/jadolg/rocketchat_API/security/code-scanning/5)

In general, the fix is to explicitly define a `permissions` block so the GITHUB_TOKEN used in this workflow is restricted to the minimum required, instead of inheriting potentially broad repository defaults. For this workflow, the job only checks out code and runs tests, so it only needs read access to the repository contents.

The best minimal change without altering functionality is to add a `permissions:` section at the workflow root (so it applies to all jobs) with `contents: read`. Concretely, in `.github/workflows/test_latest.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block and the `jobs:` block (i.e., after line 5 and the existing blank line, or replacing that blank line). No imports or additional methods are needed; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
