### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/rocketchat_API/security/code-scanning/4](https://github.com/jadolg/rocketchat_API/security/code-scanning/4)

To fix the problem, explicitly define the `permissions` for the workflow or specific job so the `GITHUB_TOKEN` has only the minimum needed scopes. Since the visible steps only check out code and then run a local action for testing, the safe minimal starting point is to grant `contents: read` either at the workflow root (applies to all jobs) or within the `test` job.

The single best fix here, without changing existing functionality, is to add a job-level `permissions` block under `jobs.test:` and above `runs-on:`. This will ensure only this job is affected and will align directly with CodeQL’s suggested minimal configuration. We’ll set:
```yaml
permissions:
  contents: read
```
No imports or other files are needed; we only adjust `.github/workflows/test.yml` by inserting these lines at the appropriate indentation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
