### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test_manually.yml
+++ b/.github/workflows/test_manually.yml
@@ -14,6 +14,8 @@ on:
 
 jobs:
   test:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
Potential fix for [https://github.com/jadolg/rocketchat_API/security/code-scanning/7](https://github.com/jadolg/rocketchat_API/security/code-scanning/7)

In general, the fix is to explicitly declare a `permissions` block that restricts the `GITHUB_TOKEN` to the minimal scope needed. Since this workflow only checks out the code and runs tests, `contents: read` should be sufficient. We can set this at the job level for the `test` job so it only affects this workflow and clearly scopes the permission.

Concretely, in `.github/workflows/test_manually.yml`, under `jobs:`, inside the `test:` job (before `runs-on:`), add a `permissions:` section with `contents: read`. This keeps existing behavior (the job can still check out the repository and run tests) while preventing unintended write operations through `GITHUB_TOKEN`. No imports or other code changes are needed; this is purely a YAML configuration update.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
