### PR TITLE
Add rooms_media_confirm and improve rooms_media input flexibility

### DIFF
--- a/rocketchat_API/APISections/rooms.py
+++ b/rocketchat_API/APISections/rooms.py
@@ -68,7 +68,8 @@ class RocketChatRooms(RocketChatBase):
     def rooms_media(self, room_id, file, **kwargs):
         """Upload media files to a room."""
         files = {
-            "file": (
+            "file": file if isinstance(file, (list, tuple))
+            else (
                 os.path.basename(file),
                 open(file, "rb"),
                 mimetypes.guess_type(file)[0],

--- a/rocketchat_API/APISections/rooms.py
+++ b/rocketchat_API/APISections/rooms.py
@@ -68,11 +68,14 @@ class RocketChatRooms(RocketChatBase):
     def rooms_media(self, room_id, file, **kwargs):
         """Upload media files to a room."""
         files = {
-            "file": file if isinstance(file, (list, tuple))
-            else (
-                os.path.basename(file),
-                open(file, "rb"),
-                mimetypes.guess_type(file)[0],
+            "file": (
+                file
+                if isinstance(file, (list, tuple))
+                else (
+                    os.path.basename(file),
+                    open(file, "rb"),
+                    mimetypes.guess_type(file)[0],
+                )
             ),
         }
         return self.call_api_post(

--- a/rocketchat_API/APISections/rooms.py
+++ b/rocketchat_API/APISections/rooms.py
@@ -77,3 +77,10 @@ class RocketChatRooms(RocketChatBase):
         return self.call_api_post(
             "rooms.media/" + room_id, kwargs=kwargs, use_json=False, files=files
         )
+
+    def rooms_media_confirm(self, room_id, file_id, **kwargs):
+        """Confirm a previously uploaded media file in a room."""
+        return self.call_api_post(
+            "rooms.mediaConfirm/" + room_id + "/" + file_id,
+            kwargs=kwargs,
+        )

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -15,6 +15,18 @@ def test_rooms_media(logged_rocket):
     assert str(rooms_media.get("file").get("url")).endswith("avatar.png")
 
 
+def test_rooms_media_array_file(logged_rocket):
+    with open("tests/assets/avatar.png", "rb") as avatar_file:
+        avatar_bytes = avatar_file.read()
+
+    rooms_media = logged_rocket.rooms_media(
+        "GENERAL",
+        file=("avatar.png", avatar_bytes, "image/png"),
+        description="hey there",
+    )
+    assert str(rooms_media.get("file").get("url")).endswith("avatar.png")
+
+
 def test_rooms_media_confirm(logged_rocket):
     uploaded_media = logged_rocket.rooms_media(
         "GENERAL", file="tests/assets/avatar.png"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -27,6 +27,19 @@ def test_rooms_media_array_file(logged_rocket):
     assert str(rooms_media.get("file").get("url")).endswith("avatar.png")
 
 
+def test_rooms_media_array_file_with_list(logged_rocket):
+    with open("tests/assets/avatar.png", "rb") as avatar_file:
+        avatar_bytes = avatar_file.read()
+
+    rooms_media = logged_rocket.rooms_media(
+        "GENERAL",
+        file=["avatar.png", avatar_bytes, "image/png"],  # list instead of tuple
+        description="hey there",
+    )
+
+    assert str(rooms_media.get("file").get("url")).endswith("avatar.png")
+
+
 def test_rooms_media_confirm(logged_rocket):
     uploaded_media = logged_rocket.rooms_media(
         "GENERAL", file="tests/assets/avatar.png"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -15,6 +15,22 @@ def test_rooms_media(logged_rocket):
     assert str(rooms_media.get("file").get("url")).endswith("avatar.png")
 
 
+def test_rooms_media_confirm(logged_rocket):
+    uploaded_media = logged_rocket.rooms_media(
+        "GENERAL", file="tests/assets/avatar.png"
+    )
+    file_id = str(uploaded_media.get("file").get("_id"))
+    assert file_id
+
+    confirmed_media = logged_rocket.rooms_media_confirm(
+        room_id="GENERAL",
+        file_id=file_id,
+        msg="confirmed upload",
+    )
+
+    assert confirmed_media.get("message").get("_id")
+
+
 def test_rooms_get(logged_rocket):
     rooms_get = logged_rocket.rooms_get()
     assert "update" in rooms_get


### PR DESCRIPTION
This change was made because the Rocket.Chat media upload API uses a two-step process: first upload and then confirm. Without rooms_media_confirm, the file gets uploaded, but the message finalization is not completed.

https://developer.rocket.chat/apidocs/check-uploaded-file

At the same time, rooms_media was updated to accept not only file paths but also pre-built tuple/list inputs, enabling direct sending of bytes and streams. This improves client flexibility, removes the need for temporary files, and provides better compatibility with real-world scenarios.

Another important benefit is that backward compatibility is preserved, and the changes are covered with tests to ensure no regression issues occur.