### PR TITLE
Support importId, email and freeSwitchExtension lookups in users_info

### DIFF
--- a/rocketchat_API/APIExceptions/RocketExceptions.py
+++ b/rocketchat_API/APIExceptions/RocketExceptions.py
@@ -5,6 +5,9 @@ ROOM_ID_OR_NAME_REQUIRED = "room_id or room_name required"
 ROOM_ID_OR_GROUP_REQUIRED = "room_id or group required"
 ROOM_ID_OR_CHANNEL_REQUIRED = "room_id or channel required"
 USER_ID_OR_USERNAME_REQUIRED = "user_id or username required"
+USER_INFO_LOOKUP_REQUIRED = (
+    "user_id, username, import_id, email or free_switch_extension required"
+)
 ROOM_ID_OR_USERNAME_REQUIRED = "room_id or username required"
 MESSAGE_RID_REQUIRED = "message.rid required"
 TEAM_ID_OR_TEAM_NAME_REQUIRED = "team_id or team_name required"

--- a/rocketchat_API/APISections/users.py
+++ b/rocketchat_API/APISections/users.py
@@ -3,6 +3,7 @@ import os
 
 from rocketchat_API.APIExceptions.RocketExceptions import (
     USER_ID_OR_USERNAME_REQUIRED,
+    USER_INFO_LOOKUP_REQUIRED,
     RocketMissingParamException,
 )
 from rocketchat_API.APISections.base import (
@@ -16,13 +17,35 @@ class RocketChatUsers(RocketChatBase):
         """Displays information about the authenticated user."""
         return self.call_api_get("me", kwargs=kwargs)
 
-    def users_info(self, user_id=None, username=None, **kwargs):
-        """Gets a user's information, limited to the caller's permissions."""
+    def users_info(
+        self,
+        user_id=None,
+        username=None,
+        import_id=None,
+        email=None,
+        free_switch_extension=None,
+        **kwargs,
+    ):
+        """Gets a user's information, limited to the caller's permissions.
+
+        Exactly one lookup parameter must be provided. ``email`` requires
+        Rocket.Chat >= 8.4.0 and ``free_switch_extension`` requires >= 8.5.0.
+        """
         if user_id:
             return self.call_api_get("users.info", userId=user_id, kwargs=kwargs)
         if username:
             return self.call_api_get("users.info", username=username, kwargs=kwargs)
-        raise RocketMissingParamException(USER_ID_OR_USERNAME_REQUIRED)
+        if import_id:
+            return self.call_api_get("users.info", importId=import_id, kwargs=kwargs)
+        if email:
+            return self.call_api_get("users.info", email=email, kwargs=kwargs)
+        if free_switch_extension:
+            return self.call_api_get(
+                "users.info",
+                freeSwitchExtension=free_switch_extension,
+                kwargs=kwargs,
+            )
+        raise RocketMissingParamException(USER_INFO_LOOKUP_REQUIRED)
 
     @paginated("users")
     def users_list(self, **kwargs):

--- a/rocketchat_API/APISections/users.py
+++ b/rocketchat_API/APISections/users.py
@@ -11,6 +11,8 @@ from rocketchat_API.APISections.base import (
     paginated,
 )
 
+USERS_INFO = "users.info"
+
 
 class RocketChatUsers(RocketChatBase):
     def me(self, **kwargs):
@@ -32,16 +34,16 @@ class RocketChatUsers(RocketChatBase):
         Rocket.Chat >= 8.4.0 and ``free_switch_extension`` requires >= 8.5.0.
         """
         if user_id:
-            return self.call_api_get("users.info", userId=user_id, kwargs=kwargs)
+            return self.call_api_get(USERS_INFO, userId=user_id, kwargs=kwargs)
         if username:
-            return self.call_api_get("users.info", username=username, kwargs=kwargs)
+            return self.call_api_get(USERS_INFO, username=username, kwargs=kwargs)
         if import_id:
-            return self.call_api_get("users.info", importId=import_id, kwargs=kwargs)
+            return self.call_api_get(USERS_INFO, importId=import_id, kwargs=kwargs)
         if email:
-            return self.call_api_get("users.info", email=email, kwargs=kwargs)
+            return self.call_api_get(USERS_INFO, email=email, kwargs=kwargs)
         if free_switch_extension:
             return self.call_api_get(
-                "users.info",
+                USERS_INFO,
                 freeSwitchExtension=free_switch_extension,
                 kwargs=kwargs,
             )

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -7,6 +7,7 @@ from rocketchat_API.APIExceptions.RocketExceptions import (
     RocketMissingParamException,
     RocketApiException,
 )
+from tests.conftest import get_tests_passowrd
 
 
 def test_login(logged_rocket, user):
@@ -53,6 +54,48 @@ def test_users_info(logged_rocket, user):
 
     with pytest.raises(RocketMissingParamException):
         logged_rocket.users_info()
+
+
+def test_users_info_by_email(logged_rocket, skip_if_version_under):
+    skip_if_version_under("8.4.0")
+    email = f"{uuid.uuid4().hex}@domain.com"
+    username = f"info_email_{uuid.uuid4().hex[:8]}"
+
+    # No user has this email yet, so the lookup must fail.
+    with pytest.raises(RocketApiException):
+        logged_rocket.users_info(email=email)
+
+    created = logged_rocket.users_create(
+        email, username, get_tests_passowrd(), username
+    )
+    user_id = created.get("user").get("_id")
+    try:
+        users_info_by_email = logged_rocket.users_info(email=email)
+        assert users_info_by_email.get("user").get("_id") == user_id
+    finally:
+        logged_rocket.users_delete(user_id)
+
+
+def test_users_info_by_import_id(logged_rocket):
+    # An importId can only be set while importing users (CSV, Slack, ...), which
+    # is not exposed through the API, so the success path cannot be set up from
+    # code. We only assert the parameter reaches the server: the API answering
+    # with a "user not found" error (rather than the wrapper raising a
+    # missing-param error) proves importId was sent as a query parameter.
+    with pytest.raises(RocketApiException):
+        logged_rocket.users_info(import_id="nonexistent")
+
+
+def test_users_info_by_free_switch_extension(logged_rocket, skip_if_version_under):
+    skip_if_version_under("8.5.0")
+    # Assigning a freeSwitchExtension requires a configured FreeSwitch server
+    # (VoIP_TeamCollab), which is part of the deployment rather than something we
+    # can set up from code, so the success path cannot be exercised here. We only
+    # assert the parameter reaches the server: the API answering with a "user not
+    # found" error (rather than the wrapper raising a missing-param error) proves
+    # freeSwitchExtension was sent as a query parameter.
+    with pytest.raises(RocketApiException):
+        logged_rocket.users_info(free_switch_extension="0000")
 
 
 def test_users_get_presence(logged_rocket, user):


### PR DESCRIPTION
Closes #386.

`users_info` only allowed `user_id` and `username` and raised before any other lookup could be used. The [API](https://developer.rocket.chat/apidocs/get-users-info) also accepts `importId`, `email` (>= 8.4.0) and `freeSwitchExtension` (>= 8.5.0), so the method now takes `import_id`, `email` and `free_switch_extension` too. Older servers are unaffected since the wrapper just forwards whichever parameter is given.